### PR TITLE
Ee 6825 push to quay

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ pipeline:
     secrets:
       - docker_password
     commands:
-      - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
+      - docker login -u="ukhomeofficedigital+pttg_ip_smoke_tests" -p=$${DOCKER_PASSWORD} quay.io
       - docker tag pttg-ip-smoke-tests quay.io/ukhomeofficedigital/pttg-ip-smoke-tests:build-$${DRONE_BUILD_NUMBER}
       - docker push quay.io/ukhomeofficedigital/pttg-ip-smoke-tests:build-$${DRONE_BUILD_NUMBER}
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ pipeline:
     commands:
       - docker build -t pttg-ip-smoke-tests .
     when:
-      branch: [master, EE-6825-push-to-quay]
+      branch: master
       event: push
 
   install-docker-image:
@@ -21,7 +21,7 @@ pipeline:
       - docker tag pttg-ip-smoke-tests quay.io/ukhomeofficedigital/pttg-ip-smoke-tests:build-$${DRONE_BUILD_NUMBER}
       - docker push quay.io/ukhomeofficedigital/pttg-ip-smoke-tests:build-$${DRONE_BUILD_NUMBER}
     when:
-      branch: [master, EE-6825-push-to-quay]
+      branch: master
       event: push
 
   smoke-test:

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,19 +23,6 @@ pipeline:
     when:
       branch: master
       event: push
-      
-  tag-docker-image-with-git-tag:
-    image: docker:17.09.1
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-    secrets:
-      - docker_password
-    commands:
-      - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag pttg-ip-smoke-tests quay.io/ukhomeofficedigital/pttg-ip-smoke-tests:$${DRONE_TAG}
-      - docker push quay.io/ukhomeofficedigital/pttg-ip-smoke-tests:$${DRONE_TAG}
-    when:
-      event: tag
 
   smoke-test:
     image: quay.io/ukhomeofficedigital/kd:v0.8.0

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ pipeline:
     commands:
       - docker build -t pttg-ip-smoke-tests .
     when:
-      branch: master
+      branch: [master, EE-6825-push-to-quay]
       event: push
 
   install-docker-image:
@@ -21,7 +21,7 @@ pipeline:
       - docker tag pttg-ip-smoke-tests quay.io/ukhomeofficedigital/pttg-ip-smoke-tests:build-$${DRONE_BUILD_NUMBER}
       - docker push quay.io/ukhomeofficedigital/pttg-ip-smoke-tests:build-$${DRONE_BUILD_NUMBER}
     when:
-      branch: master
+      branch: [master, EE-6825-push-to-quay]
       event: push
 
   smoke-test:


### PR DESCRIPTION
Changed the username to be the one that is setup for this drone build. I have tested it on a feature branch: https://drone.acp.homeoffice.gov.uk/UKHomeOffice/pttg-ip-smoke-tests/24/4 and https://quay.io/repository/ukhomeofficedigital/pttg-ip-smoke-tests?tab=tags

I've also removed the 'tag-docker-image-with-git-tag' stage as I don't believe we need it.