### PR TITLE
EE-6825 First smoke test implemented

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,4 +6,7 @@ apply plugin: 'java'
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.9'
+    testCompile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
+    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.1'
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/SimpleHttpClient.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/SimpleHttpClient.java
@@ -1,0 +1,36 @@
+package uk.gov.digital.ho.pttg;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import uk.gov.digital.ho.pttg.api.HttpResponse;
+
+import java.io.IOException;
+
+class SimpleHttpClient {
+
+    HttpResponse post(String url, String body) {
+        try {
+            return doPost(url, body);
+        } catch (IOException e) {
+            throw new AssertionError(String.format("Post to url %s failed", url), e);
+        }
+    }
+
+    private HttpResponse doPost(String url, String body) throws IOException {
+        try (CloseableHttpClient httpClient = getHttpClient()) {
+            HttpPost request = new HttpPost(url);
+            request.addHeader("Content-Type", "application/json");
+            request.setEntity(new StringEntity(body));
+            CloseableHttpResponse response = httpClient.execute(request);
+            return new HttpResponse(response.getStatusLine().getStatusCode(), EntityUtils.toString(response.getEntity()));
+        }
+    }
+
+    private CloseableHttpClient getHttpClient() {
+        return HttpClientBuilder.create().build();
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/SmokeTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/SmokeTest.java
@@ -1,7 +1,6 @@
 package uk.gov.digital.ho.pttg;
 
 import com.google.gson.*;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.digital.ho.pttg.api.FinancialStatusRequest;
@@ -18,7 +17,6 @@ public class SmokeTest {
     private final String IP_API_PATH = "/incomeproving/v3/individual/financialstatus";
 
     private String ipApiRootUrl;
-    private CloseableHttpClient httpClient;
     private SimpleHttpClient simpleHttpClient;
     private Gson gson;
 

--- a/src/test/java/uk/gov/digital/ho/pttg/SmokeTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/SmokeTest.java
@@ -1,11 +1,63 @@
 package uk.gov.digital.ho.pttg;
 
+import com.google.gson.*;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.Before;
 import org.junit.Test;
+import uk.gov.digital.ho.pttg.api.FinancialStatusRequest;
+import uk.gov.digital.ho.pttg.api.HttpResponse;
+
+import java.lang.reflect.Type;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 public class SmokeTest {
 
+    private final String IP_API_PATH = "/incomeproving/v3/individual/financialstatus";
+
+    private String ipApiRootUrl;
+    private CloseableHttpClient httpClient;
+    private SimpleHttpClient simpleHttpClient;
+    private Gson gson;
+
+    @Before
+    public void setUp() {
+        ipApiRootUrl = getMandatoryEnvVar("IP_API_ROOT_URL");
+        simpleHttpClient = new SimpleHttpClient();
+        gson = new GsonBuilder().registerTypeAdapter(LocalDate.class, new LocalDateSerializer())
+                                .create();
+    }
+
     @Test
-    public void testStartup() {
-        // TODO EE-6825 Tests yet to be added - for now it is sufficient to check that the tests run
+    public void testIpApi() {
+        String body = buildRequest();
+        System.out.println(body);
+        HttpResponse response = simpleHttpClient.post(ipApiRootUrl + IP_API_PATH, body);
+        System.out.println(response.body());
+
+        assertThat(response.statusCode()).isEqualTo(404);
+        assertThat(response.body()).contains("Resource not found");
+    }
+
+    private String buildRequest() {
+        return gson.toJson(FinancialStatusRequest.anyRequest());
+    }
+
+    private String getMandatoryEnvVar(String envVarName) {
+        String envVarValue = System.getenv(envVarName);
+        if (envVarValue == null) {
+            fail(String.format("No environment variable for %s found", envVarName));
+        }
+        return envVarValue;
+    }
+
+    private class LocalDateSerializer implements JsonSerializer<LocalDate> {
+
+        @Override
+        public JsonElement serialize(LocalDate src, Type typeOfSrc, JsonSerializationContext context) {
+            return new JsonPrimitive(src.toString());
+        }
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/api/Applicant.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/Applicant.java
@@ -1,0 +1,18 @@
+package uk.gov.digital.ho.pttg.api;
+
+import java.time.LocalDate;
+
+class Applicant {
+
+    Applicant(String forename, String surname, LocalDate dateOfBirth, String nino) {
+        this.forename = forename;
+        this.surname = surname;
+        this.dateOfBirth = dateOfBirth;
+        this.nino = nino;
+    }
+
+    private String forename;
+    private String surname;
+    private LocalDate dateOfBirth;
+    private String nino;
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/api/FinancialStatusRequest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/FinancialStatusRequest.java
@@ -1,0 +1,23 @@
+package uk.gov.digital.ho.pttg.api;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+public class FinancialStatusRequest {
+    private final List<Applicant> individuals;
+    private final LocalDate applicationRaisedDate;
+    private final Integer dependants;
+
+    private FinancialStatusRequest(List<Applicant> applicants, LocalDate applicationRaisedDate, Integer dependants) {
+        this.individuals = applicants;
+        this.applicationRaisedDate = applicationRaisedDate;
+        this.dependants = dependants;
+    }
+
+    public static FinancialStatusRequest anyRequest() {
+        return new FinancialStatusRequest(Collections.singletonList(new Applicant("Smoke", "Test", LocalDate.now(), "AA000000A")),
+                                          LocalDate.now(),
+                                          0);
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/api/HttpResponse.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/HttpResponse.java
@@ -1,0 +1,19 @@
+package uk.gov.digital.ho.pttg.api;
+
+public class HttpResponse {
+    private final int statusCode;
+    private final String body;
+
+    public HttpResponse(int statusCode, String body) {
+        this.statusCode = statusCode;
+        this.body = body;
+    }
+
+    public String body() {
+        return body;
+    }
+
+    public int statusCode() {
+        return statusCode;
+    }
+}


### PR DESCRIPTION
Simple smoke-test that will hit the Income Proving API with a non-existent identity. It checks that a 404 is returned from the service, verifying that a request has gone all the way through to HMRC and back again.