### PR TITLE
Ee 6825 pr comments and basic auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,4 +9,5 @@ dependencies {
     testCompile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.9'
     testCompile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.1'
+    testCompile group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,11 @@ apply plugin: 'java'
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.9'
-    testCompile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.1'
     testCompile group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
+
+    testCompile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.9'
+    testCompile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.9'
+    testCompile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.9'
+    testCompile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.9.9'
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/SimpleHttpClient.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/SimpleHttpClient.java
@@ -1,18 +1,38 @@
 package uk.gov.digital.ho.pttg;
 
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import uk.gov.digital.ho.pttg.api.HttpResponse;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
 
 class SimpleHttpClient {
 
-    private CloseableHttpClient httpClient = HttpClientBuilder.create().build();
+    private final Map<String, String> basicAuthConfig;
+    private final CloseableHttpClient httpClient;
+
+    SimpleHttpClient(Map<String, String> basicAuthConfig) {
+        this.basicAuthConfig = basicAuthConfig;
+        httpClient = HttpClientBuilder.create()
+                                      .setDefaultCredentialsProvider(getCredentialsProvider())
+                                      .build();
+    }
 
     HttpResponse post(String url, String body) {
         try {
@@ -27,8 +47,50 @@ class SimpleHttpClient {
         request.addHeader("Content-Type", "application/json");
         request.setEntity(new StringEntity(body));
 
-        try (CloseableHttpResponse response = httpClient.execute(request)) {
+        HttpClientContext context = getClientContext();
+
+        try (CloseableHttpResponse response = httpClient.execute(request, context)) {
             return new HttpResponse(response.getStatusLine().getStatusCode(), EntityUtils.toString(response.getEntity()));
+        }
+    }
+
+    private HttpClientContext getClientContext() {
+        HttpClientContext context = HttpClientContext.create();
+        addBasicAuth(context);
+        return context;
+    }
+
+    private void addBasicAuth(HttpClientContext context) {
+        AuthCache authCache = new BasicAuthCache();
+        BasicScheme basicAuth = new BasicScheme();
+
+        for (Map.Entry<String, String> credentialsEntry : basicAuthConfig.entrySet()) {
+            HttpHost host = extractHost(credentialsEntry.getKey());
+            authCache.put(host, basicAuth);
+        }
+        context.setAuthCache(authCache);
+    }
+
+    private CredentialsProvider getCredentialsProvider() {
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        for (Map.Entry<String, String> credentialsEntry : basicAuthConfig.entrySet()) {
+            HttpHost host = extractHost(credentialsEntry.getKey());
+            String credentials = credentialsEntry.getValue();
+            String username = credentials.split(":")[0];
+            String password = credentials.split(":")[1];
+
+            credentialsProvider.setCredentials(new AuthScope(host),
+                                               new UsernamePasswordCredentials(username, password));
+        }
+        return credentialsProvider;
+    }
+
+    private HttpHost extractHost(String url) {
+        try {
+            URI uri = new URI(url);
+            return new HttpHost(uri.getHost(), uri.getPort());
+        } catch (URISyntaxException e) {
+            throw new AssertionError(String.format("Could not get host from URL %s", url));
         }
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/SimpleHttpClient.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/SimpleHttpClient.java
@@ -69,16 +69,17 @@ class SimpleHttpClient {
 
     private CredentialsProvider getCredentialsProvider() {
         CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-        for (Map.Entry<String, String> credentialsEntry : basicAuthConfig.entrySet()) {
-            HttpHost host = extractHost(credentialsEntry.getKey());
-            String credentials = credentialsEntry.getValue();
-            String username = credentials.split(":")[0];
-            String password = credentials.split(":")[1];
-
-            credentialsProvider.setCredentials(new AuthScope(host),
-                                               new UsernamePasswordCredentials(username, password));
-        }
+        basicAuthConfig.forEach((url, credentials) -> {
+            HttpHost host = extractHost(url);
+            credentialsProvider.setCredentials(new AuthScope(host), splitCredentials(credentials));
+        });
         return credentialsProvider;
+    }
+
+    private UsernamePasswordCredentials splitCredentials(String credentials) {
+        String username = credentials.split(":")[0];
+        String password = credentials.split(":")[1];
+        return new UsernamePasswordCredentials(username, password);
     }
 
     private HttpHost extractHost(String url) {

--- a/src/test/java/uk/gov/digital/ho/pttg/SimpleHttpClient.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/SimpleHttpClient.java
@@ -24,13 +24,12 @@ import java.util.Map;
 
 class SimpleHttpClient {
 
-    private final Map<String, String> basicAuthConfig;
     private final CloseableHttpClient httpClient;
 
     SimpleHttpClient(Map<String, String> basicAuthConfig) {
-        this.basicAuthConfig = basicAuthConfig;
+        CredentialsProvider credentialsProvider = getCredentialsProvider(basicAuthConfig);
         httpClient = HttpClientBuilder.create()
-                                      .setDefaultCredentialsProvider(getCredentialsProvider())
+                                      .setDefaultCredentialsProvider(credentialsProvider)
                                       .build();
     }
 
@@ -67,7 +66,7 @@ class SimpleHttpClient {
         authCache.put(extractHost(url), new BasicScheme());
     }
 
-    private CredentialsProvider getCredentialsProvider() {
+    private CredentialsProvider getCredentialsProvider(Map<String, String> basicAuthConfig) {
         CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         basicAuthConfig.forEach((url, credentials) -> {
             HttpHost host = extractHost(url);

--- a/src/test/java/uk/gov/digital/ho/pttg/SimpleHttpClient.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/SimpleHttpClient.java
@@ -47,28 +47,24 @@ class SimpleHttpClient {
         request.addHeader("Content-Type", "application/json");
         request.setEntity(new StringEntity(body));
 
-        HttpClientContext context = getClientContext();
+        HttpClientContext context = getClientContext(url);
 
         try (CloseableHttpResponse response = httpClient.execute(request, context)) {
             return new HttpResponse(response.getStatusLine().getStatusCode(), EntityUtils.toString(response.getEntity()));
         }
     }
 
-    private HttpClientContext getClientContext() {
+    private HttpClientContext getClientContext(String url) {
         HttpClientContext context = HttpClientContext.create();
-        addBasicAuth(context);
+        addBasicAuth(context, url);
         return context;
     }
 
-    private void addBasicAuth(HttpClientContext context) {
+    private void addBasicAuth(HttpClientContext context, String url) {
         AuthCache authCache = new BasicAuthCache();
-        BasicScheme basicAuth = new BasicScheme();
-
-        for (Map.Entry<String, String> credentialsEntry : basicAuthConfig.entrySet()) {
-            HttpHost host = extractHost(credentialsEntry.getKey());
-            authCache.put(host, basicAuth);
-        }
         context.setAuthCache(authCache);
+
+        authCache.put(extractHost(url), new BasicScheme());
     }
 
     private CredentialsProvider getCredentialsProvider() {

--- a/src/test/java/uk/gov/digital/ho/pttg/SimpleHttpClient.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/SimpleHttpClient.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 
 class SimpleHttpClient {
 
+    private CloseableHttpClient httpClient = HttpClientBuilder.create().build();
+
     HttpResponse post(String url, String body) {
         try {
             return doPost(url, body);
@@ -21,16 +23,12 @@ class SimpleHttpClient {
     }
 
     private HttpResponse doPost(String url, String body) throws IOException {
-        try (CloseableHttpClient httpClient = getHttpClient()) {
-            HttpPost request = new HttpPost(url);
-            request.addHeader("Content-Type", "application/json");
-            request.setEntity(new StringEntity(body));
-            CloseableHttpResponse response = httpClient.execute(request);
+        HttpPost request = new HttpPost(url);
+        request.addHeader("Content-Type", "application/json");
+        request.setEntity(new StringEntity(body));
+
+        try (CloseableHttpResponse response = httpClient.execute(request)) {
             return new HttpResponse(response.getStatusLine().getStatusCode(), EntityUtils.toString(response.getEntity()));
         }
-    }
-
-    private CloseableHttpClient getHttpClient() {
-        return HttpClientBuilder.create().build();
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/SmokeTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/SmokeTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.YearMonthDeserializer;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import uk.gov.digital.ho.pttg.api.FinancialStatusRequest;
 import uk.gov.digital.ho.pttg.api.HttpResponse;
@@ -27,17 +28,13 @@ public class SmokeTest {
     private final String IP_API_PATH = "/incomeproving/v3/individual/financialstatus";
 
     private String ipApiRootUrl;
-    private String ipApiAuth;
 
-    private SimpleHttpClient simpleHttpClient;
-    private ObjectMapper objectMapper;
+    private SimpleHttpClient simpleHttpClient = getClient();
+    private ObjectMapper objectMapper = initialiseObjectMapper(new ObjectMapper());
 
     @Before
     public void setUp() {
         ipApiRootUrl = getMandatoryEnvVar("IP_API_ROOT_URL");
-        ipApiAuth = getMandatoryEnvVar("IP_API_AUTH");
-        simpleHttpClient = new SimpleHttpClient(Collections.singletonMap(ipApiRootUrl, ipApiAuth));
-        objectMapper = initialiseObjectMapper(new ObjectMapper());
     }
 
     @Test
@@ -51,12 +48,18 @@ public class SmokeTest {
         return objectMapper.writeValueAsString(FinancialStatusRequest.anyRequest());
     }
 
-    private String getMandatoryEnvVar(String envVarName) {
+    private static String getMandatoryEnvVar(String envVarName) {
         String envVarValue = System.getenv(envVarName);
         if (envVarValue == null) {
             fail(String.format("No environment variable for %s found", envVarName));
         }
         return envVarValue;
+    }
+
+    private static SimpleHttpClient getClient() {
+        String ipApiRootUrl = getMandatoryEnvVar("IP_API_ROOT_URL");
+        String ipApiAuth = getMandatoryEnvVar("IP_API_AUTH");
+        return new SimpleHttpClient(Collections.singletonMap(ipApiRootUrl, ipApiAuth));
     }
 
     private static ObjectMapper initialiseObjectMapper(final ObjectMapper objectMapper) {

--- a/src/test/java/uk/gov/digital/ho/pttg/SmokeTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/SmokeTest.java
@@ -38,11 +38,7 @@ public class SmokeTest {
 
     @Test
     public void testIpApi() throws JsonProcessingException {
-        String body = buildRequest();
-        System.out.println(body);
-        HttpResponse response = simpleHttpClient.post(ipApiRootUrl + IP_API_PATH, body);
-        System.out.println(response.body());
-
+        HttpResponse response = simpleHttpClient.post(ipApiRootUrl + IP_API_PATH, buildRequest());
         assertThat(response.statusCode()).isEqualTo(404);
         assertThat(response.body()).contains("Resource not found");
     }

--- a/src/test/java/uk/gov/digital/ho/pttg/SmokeTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/SmokeTest.java
@@ -17,6 +17,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -26,13 +27,16 @@ public class SmokeTest {
     private final String IP_API_PATH = "/incomeproving/v3/individual/financialstatus";
 
     private String ipApiRootUrl;
+    private String ipApiAuth;
+
     private SimpleHttpClient simpleHttpClient;
     private ObjectMapper objectMapper;
 
     @Before
     public void setUp() {
         ipApiRootUrl = getMandatoryEnvVar("IP_API_ROOT_URL");
-        simpleHttpClient = new SimpleHttpClient();
+        ipApiAuth = getMandatoryEnvVar("IP_API_AUTH");
+        simpleHttpClient = new SimpleHttpClient(Collections.singletonMap(ipApiRootUrl, ipApiAuth));
         objectMapper = initialiseObjectMapper(new ObjectMapper());
     }
 

--- a/src/test/java/uk/gov/digital/ho/pttg/SmokeTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/SmokeTest.java
@@ -1,13 +1,22 @@
 package uk.gov.digital.ho.pttg;
 
-import com.google.gson.*;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.YearMonthDeserializer;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.digital.ho.pttg.api.FinancialStatusRequest;
 import uk.gov.digital.ho.pttg.api.HttpResponse;
 
-import java.lang.reflect.Type;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -18,18 +27,17 @@ public class SmokeTest {
 
     private String ipApiRootUrl;
     private SimpleHttpClient simpleHttpClient;
-    private Gson gson;
+    private ObjectMapper objectMapper;
 
     @Before
     public void setUp() {
         ipApiRootUrl = getMandatoryEnvVar("IP_API_ROOT_URL");
         simpleHttpClient = new SimpleHttpClient();
-        gson = new GsonBuilder().registerTypeAdapter(LocalDate.class, new LocalDateSerializer())
-                                .create();
+        objectMapper = initialiseObjectMapper(new ObjectMapper());
     }
 
     @Test
-    public void testIpApi() {
+    public void testIpApi() throws JsonProcessingException {
         String body = buildRequest();
         System.out.println(body);
         HttpResponse response = simpleHttpClient.post(ipApiRootUrl + IP_API_PATH, body);
@@ -39,8 +47,8 @@ public class SmokeTest {
         assertThat(response.body()).contains("Resource not found");
     }
 
-    private String buildRequest() {
-        return gson.toJson(FinancialStatusRequest.anyRequest());
+    private String buildRequest() throws JsonProcessingException {
+        return objectMapper.writeValueAsString(FinancialStatusRequest.anyRequest());
     }
 
     private String getMandatoryEnvVar(String envVarName) {
@@ -51,11 +59,18 @@ public class SmokeTest {
         return envVarValue;
     }
 
-    private class LocalDateSerializer implements JsonSerializer<LocalDate> {
+    private static ObjectMapper initialiseObjectMapper(final ObjectMapper objectMapper) {
+        objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper.enable(JsonGenerator.Feature.WRITE_NUMBERS_AS_STRINGS);
 
-        @Override
-        public JsonElement serialize(LocalDate src, Type typeOfSrc, JsonSerializationContext context) {
-            return new JsonPrimitive(src.toString());
-        }
+        JavaTimeModule javaTimeModule = new JavaTimeModule();
+        javaTimeModule.addDeserializer(LocalDate.class, new LocalDateDeserializer(DateTimeFormatter.ofPattern("yyyy-M-d")));
+        javaTimeModule.addDeserializer(YearMonth.class, new YearMonthDeserializer(DateTimeFormatter.ofPattern("yyyy-M")));
+        objectMapper.registerModule(javaTimeModule);
+
+        return objectMapper;
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/api/Applicant.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/Applicant.java
@@ -1,13 +1,18 @@
 package uk.gov.digital.ho.pttg.api;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 
 import java.time.LocalDate;
 
 @AllArgsConstructor
 class Applicant {
+    @JsonProperty("forename")
     private String forename;
+    @JsonProperty("surname")
     private String surname;
+    @JsonProperty("dateOfBirth")
     private LocalDate dateOfBirth;
+    @JsonProperty("nino")
     private String nino;
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/api/Applicant.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/Applicant.java
@@ -1,16 +1,11 @@
 package uk.gov.digital.ho.pttg.api;
 
+import lombok.AllArgsConstructor;
+
 import java.time.LocalDate;
 
+@AllArgsConstructor
 class Applicant {
-
-    Applicant(String forename, String surname, LocalDate dateOfBirth, String nino) {
-        this.forename = forename;
-        this.surname = surname;
-        this.dateOfBirth = dateOfBirth;
-        this.nino = nino;
-    }
-
     private String forename;
     private String surname;
     private LocalDate dateOfBirth;

--- a/src/test/java/uk/gov/digital/ho/pttg/api/FinancialStatusRequest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/FinancialStatusRequest.java
@@ -1,19 +1,16 @@
 package uk.gov.digital.ho.pttg.api;
 
+import lombok.AllArgsConstructor;
+
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
+@AllArgsConstructor
 public class FinancialStatusRequest {
     private final List<Applicant> individuals;
     private final LocalDate applicationRaisedDate;
     private final Integer dependants;
-
-    private FinancialStatusRequest(List<Applicant> applicants, LocalDate applicationRaisedDate, Integer dependants) {
-        this.individuals = applicants;
-        this.applicationRaisedDate = applicationRaisedDate;
-        this.dependants = dependants;
-    }
 
     public static FinancialStatusRequest anyRequest() {
         return new FinancialStatusRequest(Collections.singletonList(new Applicant("Smoke", "Test", LocalDate.now(), "AA000000A")),

--- a/src/test/java/uk/gov/digital/ho/pttg/api/FinancialStatusRequest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/FinancialStatusRequest.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.pttg.api;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 
 import java.time.LocalDate;
@@ -8,8 +9,11 @@ import java.util.List;
 
 @AllArgsConstructor
 public class FinancialStatusRequest {
+    @JsonProperty("individuals")
     private final List<Applicant> individuals;
+    @JsonProperty("applicationRaisedDate")
     private final LocalDate applicationRaisedDate;
+    @JsonProperty("dependants")
     private final Integer dependants;
 
     public static FinancialStatusRequest anyRequest() {

--- a/src/test/java/uk/gov/digital/ho/pttg/api/HttpResponse.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/HttpResponse.java
@@ -1,19 +1,13 @@
 package uk.gov.digital.ho.pttg.api;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@AllArgsConstructor
+@Getter
+@Accessors(fluent = true)
 public class HttpResponse {
     private final int statusCode;
     private final String body;
-
-    public HttpResponse(int statusCode, String body) {
-        this.statusCode = statusCode;
-        this.body = body;
-    }
-
-    public String body() {
-        return body;
-    }
-
-    public int statusCode() {
-        return statusCode;
-    }
 }


### PR DESCRIPTION
Addressed @Tim-Hammonds comments from earlier PR that was already merged:

- Use lombok
- Use FasterXML Jackson
- Don't use a new HttpClient per request.
- Remove print statements

Made the HTTP request to pttg-ip-api include the required basic authorization header. The credentials will be an envvar defined in a configMap. This will be defined in a kube-project PR to accompany this.