### PR TITLE
Ee 6825 as a service

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,9 +19,7 @@ pipeline:
     commands:
       - docker login -u="ukhomeofficedigital+pttg_ip_smoke_tests" -p=$${DOCKER_PASSWORD} quay.io
       - docker tag pttg-ip-smoke-tests quay.io/ukhomeofficedigital/pttg-ip-smoke-tests:build-$${DRONE_BUILD_NUMBER}
-      - docker tag pttg-ip-smoke-tests quay.io/ukhomeofficedigital/pttg-ip-smoke-tests:latest
       - docker push quay.io/ukhomeofficedigital/pttg-ip-smoke-tests:build-$${DRONE_BUILD_NUMBER}
-      - docker push quay.io/ukhomeofficedigital/pttg-ip-smoke-tests:latest
     when:
       branch: master
       event: push
@@ -35,17 +33,18 @@ pipeline:
     when:
       event: [push, deployment]
 
-  smoke-test:
+  deploy-to-dev-from-build-number:
     image: quay.io/ukhomeofficedigital/kd:v1.14.0
+    environment:
+      - KUBE_NAMESPACE=pttg-ip-dev
+      - ENVIRONMENT=dev
+      - VERSION=build-${DRONE_BUILD_NUMBER}
+      - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
     secrets:
       - pttg_ip_dev
-      - pttg_ip_test
-      - pttg_ip_pr
-    environment:
-      - KUBE_NAMESPACE=pttg-ip-${DRONE_DEPLOY_TO}
-      - ENVIRONMENT=${DRONE_DEPLOY_TO}
     commands:
       - cd kube-pttg-ip-smoke-tests
       - ./deploy.sh
     when:
-      event: deployment
+      branch: master
+      event: [push, tag]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,30 @@
-FROM quay.io/ukhomeofficedigital/openjdk8:v1.8.0.171
+FROM quay.io/ukhomeofficedigital/openjdk8:v1.8.0.141
 
-USER root
 
-# Copy Test Repository into the Docker Image
-COPY . /app
-
-# Create gradle user
-ENV USER user-gradle
+ENV USER user_pttg_ip_smoke_tests
 ENV USER_ID 1001
-ENV GROUP group-gradle
+ENV GROUP group_pttg_ip_smoke_tests
+ENV NAME pttg-ip-smoke-tests
+ENV JAR_PATH build/libs
 
-# Set gradle variables
-ENV GRADLE_VERSION 4.6
-ENV GRADLE_HOME /usr/local/gradle
-ENV PATH ${PATH}:${GRADLE_HOME}/bin
-ENV GRADLE_USER_HOME /home/${USER}
-
-RUN yum install wget unzip -y -q
-
-# Install gradle - we do this instead using the wrapper so that the running container doesn't have to perform the download of Gradle.
-# This makes the container start faster and removes the dependency on the Gradle download being available.
-WORKDIR /usr/local
-RUN wget  https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip -q && \
-    unzip -q gradle-$GRADLE_VERSION-bin.zip && \
-    rm -f gradle-$GRADLE_VERSION-bin.zip && \
-    ln -s gradle-$GRADLE_VERSION gradle
-RUN groupadd ${GROUP} && \
-    useradd ${USER} -g ${GROUP} -u ${USER_ID} && \
-    chown -R ${USER}:${GROUP} /app ${GRADLE_HOME} ${GRADLE_USER_HOME}
+RUN yum update -y glibc && \
+    yum update -y nss && \
+    yum update -y bind-license
 
 WORKDIR /app
 
-# Switch user to gradle user
-USER $USER_ID
+RUN groupadd -r ${GROUP} && \
+    useradd -r -u ${USER_ID} -g ${GROUP} ${USER} -d /app && \
+    mkdir -p /app && \
+    chown -R ${USER}:${GROUP} /app
 
-ENTRYPOINT gradle build --no-daemon
+COPY ${JAR_PATH}/${NAME}*.jar /app
+COPY run.sh /app
+
+RUN chmod a+x /app/run.sh
+
+EXPOSE 8081
+
+USER ${USER_ID}
+
+ENTRYPOINT /app/run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY run.sh /app
 
 RUN chmod a+x /app/run.sh
 
-EXPOSE 8081
+EXPOSE 8080
 
 USER ${USER_ID}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/openjdk8:v1.8.0.141
+FROM quay.io/ukhomeofficedigital/openjdk8:v1.8.0.171
 
 
 ENV USER user_pttg_ip_smoke_tests

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,26 @@
+plugins {
+    id 'org.springframework.boot' version '2.1.7.RELEASE'
+}
+
 repositories {
     mavenCentral()
 }
 
 apply plugin: 'java'
+apply plugin: 'idea'
+apply plugin: 'io.spring.dependency-management'
 
 dependencies {
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
+    compile group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
+
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.9'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.1'
-    testCompile group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
+    testCompile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
+    testCompile group: 'org.apache.commons', name: 'commons-io', version: '1.3.2'
+
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '3.0.0'
 
     testCompile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.9'
     testCompile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.9'

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'io.spring.dependency-management'
 
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
 dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     compile group: 'org.projectlombok', name: 'lombok', version: '1.18.8'

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     compile group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
 
+    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
+
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.9'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.1'

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+NAME=${NAME:-pttg-ip-smoke-tests}
+
+JAR=$(find . -name ${NAME}*.jar|head -1)
+java ${JAVA_OPTS} -Dcom.sun.management.jmxremote.local.only=false -Djava.security.egd=file:/dev/./urandom -jar "${JAR}"

--- a/src/main/java/uk/gov/digital/ho/pttg/ServiceRunner.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/ServiceRunner.java
@@ -1,0 +1,11 @@
+package uk.gov.digital.ho.pttg;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ServiceRunner {
+    public static void main(String[] args) {
+        SpringApplication.run(ServiceRunner.class, args);
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResource.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResource.java
@@ -16,7 +16,7 @@ public class SmokeTestsResource {
         this.smokeTestsService = smokeTestsService;
     }
 
-    @PostMapping
+    @PostMapping("/smoketests")
     public void runSmokeTests() {
         log.info("Smoke Tests triggered");
         SmokeTestsResult smokeTestsResult = smokeTestsService.runSmokeTests();

--- a/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResource.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResource.java
@@ -1,9 +1,9 @@
 package uk.gov.digital.ho.pttg.api;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.digital.ho.pttg.application.TestFailureException;
 import uk.gov.digital.ho.pttg.testrunner.SmokeTestsService;
 
 @RestController

--- a/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResource.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResource.java
@@ -1,0 +1,43 @@
+package uk.gov.digital.ho.pttg.api;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.digital.ho.pttg.testrunner.SmokeTestsService;
+
+@RestController
+@Slf4j
+public class SmokeTestsResource {
+
+    private SmokeTestsService smokeTestsService;
+
+    public SmokeTestsResource(SmokeTestsService smokeTestsService) {
+        this.smokeTestsService = smokeTestsService;
+    }
+
+    @PostMapping
+    public SmokeTestsResult runSmokeTests() {
+        log.info("Smoke Tests triggered");
+        SmokeTestsResult smokeTestsResult = smokeTestsService.runSmokeTests();
+
+        logOutcome(smokeTestsResult);
+        return smokeTestsResult;
+    }
+
+    private void logOutcome(SmokeTestsResult result) {
+        if (result.success()) {
+            log.info("Smoke Tests successful");
+        } else {
+            String failureMessage = "Smoke Tests failed";
+            failureMessage = addReason(result.reason(), failureMessage);
+            log.info(failureMessage);
+        }
+    }
+
+    private String addReason(String reason, String failureMessage) {
+        if (reason != null) {
+            failureMessage += ": " + reason;
+        }
+        return failureMessage;
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResource.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResource.java
@@ -1,6 +1,7 @@
 package uk.gov.digital.ho.pttg.api;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.digital.ho.pttg.testrunner.SmokeTestsService;
@@ -16,12 +17,15 @@ public class SmokeTestsResource {
     }
 
     @PostMapping
-    public SmokeTestsResult runSmokeTests() {
+    public void runSmokeTests() {
         log.info("Smoke Tests triggered");
         SmokeTestsResult smokeTestsResult = smokeTestsService.runSmokeTests();
 
         logOutcome(smokeTestsResult);
-        return smokeTestsResult;
+
+        if (!smokeTestsResult.success()) {
+            throw new TestFailureException(smokeTestsResult.reason());
+        }
     }
 
     private void logOutcome(SmokeTestsResult result) {

--- a/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResult.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResult.java
@@ -1,0 +1,27 @@
+package uk.gov.digital.ho.pttg.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@AllArgsConstructor
+@Getter
+@Accessors(fluent = true)
+public class SmokeTestsResult {
+
+    public static final SmokeTestsResult SUCCESS = new SmokeTestsResult(true);
+
+    @JsonProperty("success")
+    private final boolean success;
+
+    @JsonProperty("reason")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final String reason;
+
+    public SmokeTestsResult(boolean success) {
+        this.success = success;
+        reason = null;
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/pttg/application/ResourceExceptionHandler.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/ResourceExceptionHandler.java
@@ -1,0 +1,22 @@
+package uk.gov.digital.ho.pttg.application;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@ControllerAdvice
+public class ResourceExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity handle(TestFailureException testFailureException) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(CONTENT_TYPE, APPLICATION_JSON_VALUE);
+
+        return new ResponseEntity<>(testFailureException.getMessage(), headers, INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/pttg/application/TestFailureException.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/TestFailureException.java
@@ -1,0 +1,7 @@
+package uk.gov.digital.ho.pttg.application;
+
+public class TestFailureException extends RuntimeException {
+    public TestFailureException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
@@ -1,0 +1,9 @@
+package uk.gov.digital.ho.pttg.testrunner;
+
+import uk.gov.digital.ho.pttg.api.SmokeTestsResult;
+
+public class SmokeTestsService {
+    public SmokeTestsResult runSmokeTests() {
+        return null;
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
@@ -1,7 +1,9 @@
 package uk.gov.digital.ho.pttg.testrunner;
 
+import org.springframework.stereotype.Component;
 import uk.gov.digital.ho.pttg.api.SmokeTestsResult;
 
+@Component
 public class SmokeTestsService {
     public SmokeTestsResult runSmokeTests() {
         return null;

--- a/src/test/java/uk/gov/digital/ho/pttg/SmokeTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/SmokeTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.YearMonthDeserializer;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.digital.ho.pttg.api.FinancialStatusRequest;
 import uk.gov.digital.ho.pttg.api.HttpResponse;
@@ -23,6 +24,7 @@ import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
+@Ignore("TODO EE-6825 Moving away from a Kubernetes Job that runs these tests towards a RESTful service.")
 public class SmokeTest {
 
     private final String IP_API_PATH = "/incomeproving/v3/individual/financialstatus";

--- a/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceTest.java
@@ -1,0 +1,117 @@
+package uk.gov.digital.ho.pttg.api;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+import uk.gov.digital.ho.pttg.testrunner.SmokeTestsService;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SmokeTestsResourceTest {
+
+    private static final SmokeTestsResult ANY_RESULT = new SmokeTestsResult(false);
+
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
+    @Mock
+    private SmokeTestsService mockService;
+
+    private SmokeTestsResource resource;
+    private ArgumentCaptor<ILoggingEvent> logCaptor;
+
+    @Before
+    public void setUp() {
+        Logger logger = (Logger) LoggerFactory.getLogger(SmokeTestsResource.class);
+        logger.addAppender(mockAppender);
+
+        resource = new SmokeTestsResource(mockService);
+        logCaptor = ArgumentCaptor.forClass(ILoggingEvent.class);
+    }
+
+    @Test
+    public void runSmokeTests_always_logEntry() {
+        given(mockService.runSmokeTests()).willReturn(ANY_RESULT);
+        resource.runSmokeTests();
+
+        then(mockAppender).should(atLeastOnce()).doAppend(logCaptor.capture());
+        assertLogWithMessageContaining(logCaptor.getAllValues(), "Smoke Tests", "triggered");
+    }
+
+    @Test
+    public void runSmokeTest_always_callService() {
+        given(mockService.runSmokeTests()).willReturn(ANY_RESULT);
+        resource.runSmokeTests();
+        then(mockService).should().runSmokeTests();
+    }
+
+    @Test
+    public void runSmokeTest_resultFromService_returned() {
+        SmokeTestsResult expectedResult = SmokeTestsResult.SUCCESS;
+        given(mockService.runSmokeTests()).willReturn(expectedResult);
+
+        SmokeTestsResult actualResult = resource.runSmokeTests();
+
+        assertThat(actualResult).isEqualTo(expectedResult);
+    }
+
+    @Test
+    public void runSmokeTest_success_logSuccess() {
+        given(mockService.runSmokeTests()).willReturn(SmokeTestsResult.SUCCESS);
+
+        resource.runSmokeTests();
+        then(mockAppender).should(times(2)).doAppend(logCaptor.capture());
+
+        assertLogWithMessageContaining(logCaptor.getAllValues(), "successful");
+    }
+
+    @Test
+    public void runSmokeTest_failure_logFailure() {
+        SmokeTestsResult someFailure = new SmokeTestsResult(false);
+        given(mockService.runSmokeTests()).willReturn(someFailure);
+
+        resource.runSmokeTests();
+        then(mockAppender).should(times(2)).doAppend(logCaptor.capture());
+
+        assertLogWithMessageContaining(logCaptor.getAllValues(), "failed");
+    }
+
+    @Test
+    public void runSmokeTest_failureWithReason_logReason() {
+        String someReason = "some reason for failure";
+
+        SmokeTestsResult someFailureWithReason = new SmokeTestsResult(false, someReason);
+        given(mockService.runSmokeTests()).willReturn(someFailureWithReason);
+
+        resource.runSmokeTests();
+        then(mockAppender).should(times(2)).doAppend(logCaptor.capture());
+
+        assertLogWithMessageContaining(logCaptor.getAllValues(), "failed", someReason);
+    }
+
+    public ILoggingEvent assertLogWithMessageContaining(List<ILoggingEvent> loggingEvents, String... expectedMessageContents) {
+        return loggingEvents.stream()
+                            .filter(loggingEvent -> containsAllMessageParts(loggingEvent, expectedMessageContents))
+                            .findFirst()
+                            .orElseThrow(AssertionError::new);
+    }
+
+    private boolean containsAllMessageParts(ILoggingEvent loggingEvent, String[] expectedMessageContents) {
+        return Arrays.stream(expectedMessageContents)
+                     .allMatch(expectedMessagePart -> loggingEvent.getFormattedMessage().contains(expectedMessagePart));
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceTest.java
@@ -12,6 +12,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
+import uk.gov.digital.ho.pttg.application.TestFailureException;
 import uk.gov.digital.ho.pttg.testrunner.SmokeTestsService;
 
 import java.util.Arrays;

--- a/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceWebTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceWebTest.java
@@ -1,0 +1,84 @@
+package uk.gov.digital.ho.pttg.api;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.digital.ho.pttg.testrunner.SmokeTestsService;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(SmokeTestsResource.class)
+public class SmokeTestsResourceWebTest {
+
+    private static final String SMOKE_TESTS_PATH = "/smoketests";
+
+    @MockBean
+    private SmokeTestsService mockService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void runSmokeTests_get_methodNotAllowed() throws Exception {
+        mockMvc.perform(get(SMOKE_TESTS_PATH))
+               .andExpect(status().isMethodNotAllowed());
+    }
+
+    @Test
+    public void runSmokeTests_testSuccess_returnSuccess() throws Exception {
+        when(mockService.runSmokeTests()).thenReturn(SmokeTestsResult.SUCCESS);
+
+        mockMvc.perform(post(SMOKE_TESTS_PATH))
+               .andExpect(status().isOk());
+    }
+
+    @Test
+    public void runSmokeTests_testSuccess_emptyBody() throws Exception {
+        when(mockService.runSmokeTests()).thenReturn(SmokeTestsResult.SUCCESS);
+
+        mockMvc.perform(post(SMOKE_TESTS_PATH))
+               .andExpect(content().string(""));
+    }
+
+    @Test
+    public void runSmokeTests_testFailure_returnInternalServerError() throws Exception {
+        when(mockService.runSmokeTests()).thenReturn(new SmokeTestsResult(false));
+
+        mockMvc.perform(post(SMOKE_TESTS_PATH))
+               .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    public void runSmokeTests_testFailure_jsonHeader() throws Exception {
+        when(mockService.runSmokeTests()).thenReturn(new SmokeTestsResult(false));
+
+        mockMvc.perform(post(SMOKE_TESTS_PATH))
+               .andExpect(header().string("Content-Type", "application/json"));
+    }
+
+    @Test
+    public void runSmokeTests_testFailureWithoutMessage_emptyResponse() throws Exception {
+        when(mockService.runSmokeTests()).thenReturn(new SmokeTestsResult(false));
+
+        mockMvc.perform(post(SMOKE_TESTS_PATH))
+               .andExpect(content().string(""));
+    }
+
+    @Test
+    public void runSmokeTests_testFailureWithMessage_messageInResponse() throws Exception {
+        String someFailureReason = "some failure reason";
+        when(mockService.runSmokeTests()).thenReturn(new SmokeTestsResult(false, someFailureReason));
+
+        mockMvc.perform(post(SMOKE_TESTS_PATH))
+               .andExpect(content().string(someFailureReason));
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResultTests.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResultTests.java
@@ -1,0 +1,65 @@
+package uk.gov.digital.ho.pttg.api;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SmokeTestsResultTests {
+
+    private static final boolean ANY_BOOLEAN = false;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void serialization_success_serializes() throws JsonProcessingException {
+        SmokeTestsResult someResult = new SmokeTestsResult(true);
+        String serializedResult = objectMapper.writeValueAsString(someResult);
+        boolean success = JsonPath.read(serializedResult, "$.success");
+        assertThat(success).isTrue();
+    }
+
+    @Test
+    public void serialization_failure_serializes() throws JsonProcessingException {
+        SmokeTestsResult someResult = new SmokeTestsResult(false);
+        String serializedResult = objectMapper.writeValueAsString(someResult);
+        boolean success = JsonPath.read(serializedResult, "$.success");
+        assertThat(success).isFalse();
+    }
+
+    @Test
+    public void serialization_noReason_doNotIncludeInSerialization() throws JsonProcessingException {
+        SmokeTestsResult noReason = new SmokeTestsResult(ANY_BOOLEAN);
+        String serializedResult = objectMapper.writeValueAsString(noReason);
+
+        expectedException.expect(PathNotFoundException.class);
+        JsonPath.read(serializedResult, "$.reason");
+    }
+
+    @Test
+    public void serialization_emptyReason_doNotIncludeInSerialization() throws JsonProcessingException {
+        SmokeTestsResult emptyReason = new SmokeTestsResult(ANY_BOOLEAN, "");
+        String serializedResult = objectMapper.writeValueAsString(emptyReason);
+
+        expectedException.expect(PathNotFoundException.class);
+        JsonPath.read(serializedResult, "$.reason");
+    }
+
+    @Test
+    public void serialization_someReason_serializes() throws JsonProcessingException {
+        SmokeTestsResult someResultWithReason = new SmokeTestsResult(ANY_BOOLEAN, "expected reason");
+        String serializedResult = objectMapper.writeValueAsString(someResultWithReason);
+
+        String actualReason = JsonPath.read(serializedResult, "$.reason");
+        assertThat(actualReason).isEqualTo("expected reason");
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResultTests.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResultTests.java
@@ -5,20 +5,16 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SmokeTestsResultTests {
 
     private static final boolean ANY_BOOLEAN = false;
 
     private ObjectMapper objectMapper = new ObjectMapper();
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void serialization_success_serializes() throws JsonProcessingException {
@@ -41,8 +37,8 @@ public class SmokeTestsResultTests {
         SmokeTestsResult noReason = new SmokeTestsResult(ANY_BOOLEAN);
         String serializedResult = objectMapper.writeValueAsString(noReason);
 
-        expectedException.expect(PathNotFoundException.class);
-        JsonPath.read(serializedResult, "$.reason");
+        assertThatThrownBy(() -> JsonPath.read(serializedResult, "$.reason"))
+                .isInstanceOf(PathNotFoundException.class);
     }
 
     @Test
@@ -50,8 +46,8 @@ public class SmokeTestsResultTests {
         SmokeTestsResult emptyReason = new SmokeTestsResult(ANY_BOOLEAN, "");
         String serializedResult = objectMapper.writeValueAsString(emptyReason);
 
-        expectedException.expect(PathNotFoundException.class);
-        JsonPath.read(serializedResult, "$.reason");
+        assertThatThrownBy(() -> JsonPath.read(serializedResult, "$.reason"))
+                .isInstanceOf(PathNotFoundException.class);
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/pttg/application/ResourceExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/ResourceExceptionHandlerTest.java
@@ -1,0 +1,40 @@
+package uk.gov.digital.ho.pttg.application;
+
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+public class ResourceExceptionHandlerTest {
+
+    private static final TestFailureException ANY_TEST_FAILURE_EXCEPTION = new TestFailureException("any message");
+
+    private ResourceExceptionHandler exceptionHandler = new ResourceExceptionHandler();
+
+    @Test
+    public void handle_TestFailureException_internalServerError() {
+        ResponseEntity responseEntity = exceptionHandler.handle(ANY_TEST_FAILURE_EXCEPTION);
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    public void handle_TestFailureException_includeExceptionMessage() {
+        String expectedMessage = "some error";
+        ResponseEntity responseEntity = exceptionHandler.handle(new TestFailureException(expectedMessage));
+
+        assertThat(responseEntity.getBody()).isEqualTo(expectedMessage);
+    }
+
+    @Test
+    public void handle_TestFailureException_expectedHeaders() {
+        ResponseEntity responseEntity = exceptionHandler.handle(ANY_TEST_FAILURE_EXCEPTION);
+
+        assertThat(responseEntity.getHeaders()).containsEntry(CONTENT_TYPE, Collections.singletonList(APPLICATION_JSON_VALUE));
+    }
+}


### PR DESCRIPTION
Starting to change the smoke tests to be a service that is deployed to the namespace and has an endpoint to trigger tests. I have created the Resource and tested but not implemented the underlying service so currently it doesn't test anything.

I intend to merge to master immediately as the smoke tests aren't yet in use. Accompanied by https://github.com/UKHomeOffice/kube-pttg-ip-smoke-tests/pull/6