### PR TITLE
Ee 6825 implement test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,13 +16,13 @@ targetCompatibility = 1.8
 dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     compile group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
+    compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
 
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.9'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.1'
-    testCompile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
     testCompile group: 'org.apache.commons', name: 'commons-io', version: '1.3.2'
 
     testCompile group: 'org.mockito', name: 'mockito-core', version: '3.0.0'

--- a/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResource.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResource.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.pttg.api;
 
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -8,13 +9,10 @@ import uk.gov.digital.ho.pttg.testrunner.SmokeTestsService;
 
 @RestController
 @Slf4j
+@AllArgsConstructor
 public class SmokeTestsResource {
 
-    private SmokeTestsService smokeTestsService;
-
-    public SmokeTestsResource(SmokeTestsService smokeTestsService) {
-        this.smokeTestsService = smokeTestsService;
-    }
+    private final SmokeTestsService smokeTestsService;
 
     @PostMapping("/smoketests")
     public void runSmokeTests() {

--- a/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResult.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResult.java
@@ -3,12 +3,14 @@ package uk.gov.digital.ho.pttg.api;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
 @AllArgsConstructor
 @Getter
 @Accessors(fluent = true)
+@EqualsAndHashCode
 public class SmokeTestsResult {
 
     public static final SmokeTestsResult SUCCESS = new SmokeTestsResult(true);

--- a/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResult.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/SmokeTestsResult.java
@@ -5,12 +5,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 import lombok.experimental.Accessors;
 
 @AllArgsConstructor
 @Getter
 @Accessors(fluent = true)
 @EqualsAndHashCode
+@ToString
 public class SmokeTestsResult {
 
     public static final SmokeTestsResult SUCCESS = new SmokeTestsResult(true);

--- a/src/main/java/uk/gov/digital/ho/pttg/application/ServiceConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/ServiceConfiguration.java
@@ -15,6 +15,7 @@ import java.time.format.DateTimeFormatter;
 @Configuration
 public class ServiceConfiguration {
 
+    @Bean
     public ObjectMapper createObjectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
 

--- a/src/main/java/uk/gov/digital/ho/pttg/application/ServiceConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/ServiceConfiguration.java
@@ -1,0 +1,27 @@
+package uk.gov.digital.ho.pttg.application;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Configuration
+public class ServiceConfiguration {
+
+    public ObjectMapper createObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        JavaTimeModule javaTimeModule = new JavaTimeModule();
+        javaTimeModule.addDeserializer(LocalDate.class, new LocalDateDeserializer(DateTimeFormatter.ofPattern("yyyy-M-d")));
+        objectMapper.registerModule(javaTimeModule);
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+        objectMapper.writer().withDefaultPrettyPrinter();
+        return objectMapper;
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/pttg/application/ServiceConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/ServiceConfiguration.java
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -23,5 +26,10 @@ public class ServiceConfiguration {
         objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
         objectMapper.writer().withDefaultPrettyPrinter();
         return objectMapper;
+    }
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder.build();
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/ServiceConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/ServiceConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
@@ -32,5 +33,10 @@ public class ServiceConfiguration {
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
         return restTemplateBuilder.build();
+    }
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/IpsClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/IpsClient.java
@@ -1,0 +1,4 @@
+package uk.gov.digital.ho.pttg.testrunner;
+
+public class IpsClient {
+}

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/IpsClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/IpsClient.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.pttg.testrunner;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +21,7 @@ public class IpsClient {
     private final String basicAuth;
     private RestTemplate restTemplate;
 
-    public IpsClient(String ipsEndpoint, String basicAuth, RestTemplate restTemplate) {
+    public IpsClient(@Value("${ips.endpoint}") String ipsEndpoint, @Value("${ips.basicauth}") String basicAuth, RestTemplate restTemplate) {
         this.ipsEndpoint = ipsEndpoint;
         this.basicAuth = basicAuth;
         this.restTemplate = restTemplate;

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/IpsClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/IpsClient.java
@@ -1,4 +1,38 @@
 package uk.gov.digital.ho.pttg.testrunner;
 
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.digital.ho.pttg.testrunner.domain.FinancialStatusRequest;
+
+import java.util.Base64;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
 public class IpsClient {
+
+    private final String ipsEndpoint;
+    private final String basicAuth;
+    private RestTemplate restTemplate;
+
+    public IpsClient(String ipsEndpoint, String basicAuth, RestTemplate restTemplate) {
+        this.ipsEndpoint = ipsEndpoint;
+        this.basicAuth = basicAuth;
+        this.restTemplate = restTemplate;
+    }
+
+    public ResponseEntity<Void> sendFinancialStatusRequest(FinancialStatusRequest financialStatusRequest) {
+        return restTemplate.exchange(ipsEndpoint, POST, new HttpEntity<>(financialStatusRequest, getHeaders()), Void.class);
+    }
+
+    private HttpHeaders getHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(APPLICATION_JSON);
+        headers.add(AUTHORIZATION, String.format("Basic %s", Base64.getEncoder().encodeToString(basicAuth.getBytes())));
+        return headers;
+    }
 }
+

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/IpsClient.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/IpsClient.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.pttg.testrunner;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.digital.ho.pttg.testrunner.domain.FinancialStatusRequest;
 
@@ -12,6 +13,7 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
+@Component
 public class IpsClient {
 
     private final String ipsEndpoint;

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
@@ -2,12 +2,11 @@ package uk.gov.digital.ho.pttg.testrunner;
 
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
+import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestClientResponseException;
 import uk.gov.digital.ho.pttg.api.SmokeTestsResult;
 import uk.gov.digital.ho.pttg.testrunner.domain.Applicant;
 import uk.gov.digital.ho.pttg.testrunner.domain.FinancialStatusRequest;
@@ -16,13 +15,10 @@ import java.time.LocalDate;
 import java.util.Collections;
 
 @Component
+@AllArgsConstructor
 public class SmokeTestsService {
 
     private final IpsClient ipsClient;
-
-    public SmokeTestsService(IpsClient ipsClient) {
-        this.ipsClient = ipsClient;
-    }
 
     public SmokeTestsResult runSmokeTests() {
         try {

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
@@ -2,6 +2,7 @@ package uk.gov.digital.ho.pttg.testrunner;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
 import uk.gov.digital.ho.pttg.api.SmokeTestsResult;
 import uk.gov.digital.ho.pttg.testrunner.domain.Applicant;
 import uk.gov.digital.ho.pttg.testrunner.domain.FinancialStatusRequest;
@@ -22,6 +23,8 @@ public class SmokeTestsService {
         try {
             ipsClient.sendFinancialStatusRequest(someRequest());
             return SmokeTestsResult.SUCCESS;
+        } catch (RestClientResponseException e) {
+            return new SmokeTestsResult(false, e.getResponseBodyAsString());
         } catch (RestClientException e) {
             return new SmokeTestsResult(false, e.getMessage());
         }

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
@@ -3,16 +3,32 @@ package uk.gov.digital.ho.pttg.testrunner;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import uk.gov.digital.ho.pttg.api.SmokeTestsResult;
+import uk.gov.digital.ho.pttg.testrunner.domain.Applicant;
+import uk.gov.digital.ho.pttg.testrunner.domain.FinancialStatusRequest;
+
+import java.time.LocalDate;
+import java.util.Collections;
 
 @Component
 public class SmokeTestsService {
+
+    private final IpsClient ipsClient;
+
+    public SmokeTestsService(IpsClient ipsClient) {
+        this.ipsClient = ipsClient;
+    }
+
     public SmokeTestsResult runSmokeTests() {
-//        try{
-//            ipsClient.sendFinancialStatusRequest(someRequest);
-//            return positive response
-//        } catch (RestClientException e){
-//return failure
-//        }
-        return null;
+        try {
+            ipsClient.sendFinancialStatusRequest(someRequest());
+            return SmokeTestsResult.SUCCESS;
+        } catch (RestClientException e) {
+            return new SmokeTestsResult(false, e.getMessage());
+        }
+    }
+
+    private FinancialStatusRequest someRequest() {
+        Applicant someApplicant = new Applicant("smoke", "tests", LocalDate.now(), "AA000000A");
+        return new FinancialStatusRequest(Collections.singletonList(someApplicant), LocalDate.now(), 0);
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
@@ -11,6 +11,7 @@ import uk.gov.digital.ho.pttg.api.SmokeTestsResult;
 import uk.gov.digital.ho.pttg.testrunner.domain.Applicant;
 import uk.gov.digital.ho.pttg.testrunner.domain.FinancialStatusRequest;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.Collections;
 
@@ -19,6 +20,7 @@ import java.util.Collections;
 public class SmokeTestsService {
 
     private final IpsClient ipsClient;
+    private final Clock clock;
 
     public SmokeTestsResult runSmokeTests() {
         try {
@@ -44,7 +46,7 @@ public class SmokeTestsService {
     }
 
     private FinancialStatusRequest someRequest() {
-        Applicant someApplicant = new Applicant("smoke", "tests", LocalDate.now(), "AA000000A");
-        return new FinancialStatusRequest(Collections.singletonList(someApplicant), LocalDate.now(), 0);
+        Applicant someApplicant = new Applicant("smoke", "tests", LocalDate.now(clock), "AA000000A");
+        return new FinancialStatusRequest(Collections.singletonList(someApplicant), LocalDate.now(clock), 0);
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
@@ -1,11 +1,18 @@
 package uk.gov.digital.ho.pttg.testrunner;
 
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
 import uk.gov.digital.ho.pttg.api.SmokeTestsResult;
 
 @Component
 public class SmokeTestsService {
     public SmokeTestsResult runSmokeTests() {
+//        try{
+//            ipsClient.sendFinancialStatusRequest(someRequest);
+//            return positive response
+//        } catch (RestClientException e){
+//return failure
+//        }
         return null;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/domain/Applicant.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/domain/Applicant.java
@@ -1,9 +1,11 @@
 package uk.gov.digital.ho.pttg.testrunner.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 
 import java.time.LocalDate;
 
+@AllArgsConstructor
 public class Applicant {
     @JsonProperty("forename")
     private final String forename;
@@ -16,11 +18,4 @@ public class Applicant {
 
     @JsonProperty("nino")
     private final String nino;
-
-    public Applicant(String forename, String surname, LocalDate dateOfBirth, String nino) {
-        this.forename = forename;
-        this.surname = surname;
-        this.dateOfBirth = dateOfBirth;
-        this.nino = nino;
-    }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/domain/Applicant.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/domain/Applicant.java
@@ -2,10 +2,12 @@ package uk.gov.digital.ho.pttg.testrunner.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 
 import java.time.LocalDate;
 
 @AllArgsConstructor
+@EqualsAndHashCode
 public class Applicant {
     @JsonProperty("forename")
     private final String forename;

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/domain/Applicant.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/domain/Applicant.java
@@ -1,0 +1,26 @@
+package uk.gov.digital.ho.pttg.testrunner.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+
+public class Applicant {
+    @JsonProperty("forename")
+    private final String forename;
+
+    @JsonProperty("surname")
+    private final String surname;
+
+    @JsonProperty("dateOfBirth")
+    private final LocalDate dateOfBirth;
+
+    @JsonProperty("nino")
+    private final String nino;
+
+    public Applicant(String forename, String surname, LocalDate dateOfBirth, String nino) {
+        this.forename = forename;
+        this.surname = surname;
+        this.dateOfBirth = dateOfBirth;
+        this.nino = nino;
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/domain/FinancialStatusRequest.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/domain/FinancialStatusRequest.java
@@ -1,0 +1,4 @@
+package uk.gov.digital.ho.pttg.testrunner.domain;
+
+public class FinancialStatusRequest {
+}

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/domain/FinancialStatusRequest.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/domain/FinancialStatusRequest.java
@@ -1,4 +1,29 @@
 package uk.gov.digital.ho.pttg.testrunner.domain;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 public class FinancialStatusRequest {
+
+    @JsonProperty("individuals")
+    private final List<Applicant> applicants;
+
+    @JsonProperty("applicationRaisedDate")
+    private final LocalDate applicationRaisedDate;
+
+    @JsonProperty("dependants")
+    @JsonInclude(NON_NULL)
+    private final Integer dependants;
+
+
+    public FinancialStatusRequest(List<Applicant> applicants, LocalDate applicationRaisedDate, Integer dependants) {
+        this.applicants = applicants;
+        this.applicationRaisedDate = applicationRaisedDate;
+        this.dependants = dependants;
+    }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/domain/FinancialStatusRequest.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/domain/FinancialStatusRequest.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.pttg.testrunner.domain;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.List;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @AllArgsConstructor
+@EqualsAndHashCode
 public class FinancialStatusRequest {
 
     @JsonProperty("individuals")

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/domain/FinancialStatusRequest.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/domain/FinancialStatusRequest.java
@@ -2,12 +2,14 @@ package uk.gov.digital.ho.pttg.testrunner.domain;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 
 import java.time.LocalDate;
 import java.util.List;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
+@AllArgsConstructor
 public class FinancialStatusRequest {
 
     @JsonProperty("individuals")
@@ -19,11 +21,4 @@ public class FinancialStatusRequest {
     @JsonProperty("dependants")
     @JsonInclude(NON_NULL)
     private final Integer dependants;
-
-
-    public FinancialStatusRequest(List<Applicant> applicants, LocalDate applicationRaisedDate, Integer dependants) {
-        this.applicants = applicants;
-        this.applicationRaisedDate = applicationRaisedDate;
-        this.dependants = dependants;
-    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+ips.endpoint=http://localhost:8081/incomeproving/v3/individual/financialstatus
+ips.basicauth=someuser:somepass

--- a/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceIT.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceIT.java
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
@@ -47,7 +47,7 @@ public class SmokeTestsResourceIT {
         mockIpsService.expect(requestTo(containsString("/incomeproving/v3/individual/financialstatus")))
                       .andExpect(method(POST))
                       .andExpect(jsonPath("$.individuals[0].forename", equalTo("smoke")))
-                      .andRespond(withSuccess());
+                      .andRespond(withStatus(HttpStatus.NOT_FOUND).body("{\"code\": \"0009\", \"message\": \"Resource not found\"}"));
 
         ResponseEntity<Void> response = testRestTemplate.exchange("/smoketests", POST, new HttpEntity<>(""), Void.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceIT.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceIT.java
@@ -1,0 +1,68 @@
+package uk.gov.digital.ho.pttg.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        properties = {
+                "ips.endpoint=http://ips.endpoint/incomeproving/v3/individual/financialstatus",
+                "ips.basicauth=someuser:somepass",
+        },
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class SmokeTestsResourceIT {
+
+    @Autowired
+    private RestTemplate restTemplate;
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    private MockRestServiceServer mockIpsService;
+
+    @Before
+    public void setUp() {
+        mockIpsService = MockRestServiceServer.bindTo(restTemplate).build();
+    }
+
+    @Test
+    public void runSmokeTests_testSuccess_returnSuccess() {
+        mockIpsService.expect(requestTo(containsString("/incomeproving/v3/individual/financialstatus")))
+                      .andExpect(method(POST))
+                      .andExpect(jsonPath("$.individuals[0].forename", equalTo("smoke")))
+                      .andRespond(withSuccess());
+
+        ResponseEntity<Void> response = testRestTemplate.exchange("/smoketests", POST, new HttpEntity<>(""), Void.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void runSmokeTests_testFailure_returnFailure() {
+        String someErrorMessage = "some error";
+        mockIpsService.expect(requestTo(containsString("/incomeproving/v3/individual/financialstatus")))
+                      .andExpect(method(POST))
+                      .andExpect(jsonPath("$.individuals[0].forename", equalTo("smoke")))
+                      .andRespond(withServerError().body(someErrorMessage));
+
+        ResponseEntity<String> response = testRestTemplate.exchange("/smoketests", POST, new HttpEntity<>(""), String.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).contains(someErrorMessage);
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/testrunner/IpsClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/testrunner/IpsClientTest.java
@@ -1,5 +1,86 @@
 package uk.gov.digital.ho.pttg.testrunner;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.digital.ho.pttg.testrunner.domain.FinancialStatusRequest;
+
+import java.time.LocalDate;
+import java.util.Base64;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+@RunWith(MockitoJUnitRunner.class)
 public class IpsClientTest {
 
+    private static final String SOME_IPS_ENDPOINT = "http://someurl/incomeproving/v3/individual/financialstatus";
+    private static final String SOME_BASIC_AUTH = "someuser:somepass";
+    private static final FinancialStatusRequest ANY_REQUEST = new FinancialStatusRequest(Collections.emptyList(), LocalDate.now(), 0);
+    @Mock
+    private RestTemplate mockRestTemplate;
+
+    private IpsClient ipsClient;
+
+    private ArgumentCaptor<HttpEntity> httpEntityCaptor;
+
+    @Before
+    public void setUp() {
+        ipsClient = new IpsClient(SOME_IPS_ENDPOINT, SOME_BASIC_AUTH, mockRestTemplate);
+        httpEntityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    }
+
+    @Test
+    public void sendFinancialStatusRequest_givenRequest_passedToRestTemplate() {
+        FinancialStatusRequest someRequest = new FinancialStatusRequest(Collections.emptyList(), LocalDate.now(), 0);
+        ipsClient.sendFinancialStatusRequest(someRequest);
+
+        then(mockRestTemplate).should()
+                              .exchange(eq(SOME_IPS_ENDPOINT), eq(POST), httpEntityCaptor.capture(), eq(Void.class));
+        assertThat((FinancialStatusRequest) httpEntityCaptor.getValue().getBody()).isEqualTo(someRequest);
+    }
+
+    @Test
+    public void sendFinancialStatusRequest_anyRequest_contentTypeJson() {
+        ipsClient.sendFinancialStatusRequest(ANY_REQUEST);
+
+        then(mockRestTemplate).should()
+                              .exchange(eq(SOME_IPS_ENDPOINT), eq(POST), httpEntityCaptor.capture(), eq(Void.class));
+        HttpHeaders headers = httpEntityCaptor.getValue().getHeaders();
+        assertThat(headers.getContentType()).isEqualTo(APPLICATION_JSON);
+    }
+
+    @Test
+    public void sendFinancialStatusRequest_anyRequest_includeBasicAuthHeader() {
+        ipsClient.sendFinancialStatusRequest(ANY_REQUEST);
+
+        then(mockRestTemplate).should()
+                              .exchange(eq(SOME_IPS_ENDPOINT), eq(POST), httpEntityCaptor.capture(), eq(Void.class));
+        HttpHeaders headers = httpEntityCaptor.getValue().getHeaders();
+        assertThat(headers.get("Authorization").get(0)).isEqualTo("Basic " + Base64.getEncoder().encodeToString(SOME_BASIC_AUTH.getBytes()));
+    }
+
+    @Test
+    public void sendFinancialStatusRequest_responseFromIps_returned() {
+        ResponseEntity<Void> expectedResponse = new ResponseEntity<>(HttpStatus.OK);
+        given(mockRestTemplate.exchange(eq(SOME_IPS_ENDPOINT), eq(POST), any(HttpEntity.class), eq(Void.class)))
+                .willReturn(expectedResponse);
+
+        ResponseEntity<Void> actualResponse = ipsClient.sendFinancialStatusRequest(ANY_REQUEST);
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/testrunner/IpsClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/testrunner/IpsClientTest.java
@@ -1,0 +1,5 @@
+package uk.gov.digital.ho.pttg.testrunner;
+
+public class IpsClientTest {
+
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsServiceTest.java
@@ -1,0 +1,68 @@
+package uk.gov.digital.ho.pttg.testrunner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import uk.gov.digital.ho.pttg.api.SmokeTestsResult;
+import uk.gov.digital.ho.pttg.testrunner.domain.Applicant;
+import uk.gov.digital.ho.pttg.testrunner.domain.FinancialStatusRequest;
+
+import java.time.LocalDate;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SmokeTestsServiceTest {
+
+    @Mock
+    private IpsClient mockIpsClient;
+
+    private SmokeTestsService service;
+    private ArgumentCaptor<FinancialStatusRequest> requestCaptor;
+
+    @Before
+    public void setUp() {
+        service = new SmokeTestsService(mockIpsClient);
+        requestCaptor = ArgumentCaptor.forClass(FinancialStatusRequest.class);
+    }
+
+    @Test
+    public void runSmokeTests_always_callIpsWithTestRequest() {
+        service.runSmokeTests();
+
+        then(mockIpsClient).should().sendFinancialStatusRequest(requestCaptor.capture());
+        FinancialStatusRequest expectedRequest = new FinancialStatusRequest(
+                Collections.singletonList(new Applicant("smoke", "tests", LocalDate.now(), "AA000000A")),
+                LocalDate.now(),
+                0);
+        assertThat(requestCaptor.getValue()).isEqualTo(expectedRequest);
+    }
+
+    @Test
+    public void runSmokeTests_financialStatusRequestSuccess_returnSuccess() {
+        given(mockIpsClient.sendFinancialStatusRequest(any())).willReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        SmokeTestsResult testsResult = service.runSmokeTests();
+
+        assertThat(testsResult).isEqualTo(SmokeTestsResult.SUCCESS);
+    }
+
+    @Test
+    public void runSmokeTests_financialStatusRequestFailure_returnFailure() {
+        given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(new RestClientException("some failure message"));
+
+        SmokeTestsResult testsResult = service.runSmokeTests();
+
+        assertThat(testsResult).isEqualTo(new SmokeTestsResult(false, "some failure message"));
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsServiceTest.java
@@ -14,7 +14,10 @@ import uk.gov.digital.ho.pttg.api.SmokeTestsResult;
 import uk.gov.digital.ho.pttg.testrunner.domain.Applicant;
 import uk.gov.digital.ho.pttg.testrunner.domain.FinancialStatusRequest;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,10 +34,16 @@ public class SmokeTestsServiceTest {
 
     private SmokeTestsService service;
     private ArgumentCaptor<FinancialStatusRequest> requestCaptor;
+    private Clock fixedClock;
 
     @Before
     public void setUp() {
-        service = new SmokeTestsService(mockIpsClient);
+        LocalDate anyDate = LocalDate.of(2019, 8, 23);;
+        Instant instant = Instant.from(anyDate.atStartOfDay().atZone(ZoneId.systemDefault()));
+        fixedClock = Clock.fixed(instant, ZoneId.systemDefault());
+
+        service = new SmokeTestsService(mockIpsClient, fixedClock);
+
         requestCaptor = ArgumentCaptor.forClass(FinancialStatusRequest.class);
     }
 
@@ -44,8 +53,8 @@ public class SmokeTestsServiceTest {
 
         then(mockIpsClient).should().sendFinancialStatusRequest(requestCaptor.capture());
         FinancialStatusRequest expectedRequest = new FinancialStatusRequest(
-                Collections.singletonList(new Applicant("smoke", "tests", LocalDate.now(), "AA000000A")),
-                LocalDate.now(),
+                Collections.singletonList(new Applicant("smoke", "tests", LocalDate.now(fixedClock), "AA000000A")),
+                LocalDate.now(fixedClock),
                 0);
         assertThat(requestCaptor.getValue()).isEqualTo(expectedRequest);
     }

--- a/src/test/java/uk/gov/digital/ho/pttg/testrunner/domain/ApplicantTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/testrunner/domain/ApplicantTest.java
@@ -1,0 +1,51 @@
+package uk.gov.digital.ho.pttg.testrunner.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.Test;
+import uk.gov.digital.ho.pttg.application.ServiceConfiguration;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ApplicantTest {
+
+    private final ObjectMapper objectMapper = new ServiceConfiguration().createObjectMapper();
+
+    private static final String SOME_DATE_OF_BIRTH = "2019-08-20";
+    private static final Applicant SOME_APPLICANT = new Applicant("some forename", "some surname", LocalDate.parse(SOME_DATE_OF_BIRTH), "some nino");
+
+    @Test
+    public void serialization_someApplicant_serializeForename() throws JsonProcessingException {
+        String serialized = objectMapper.writeValueAsString(SOME_APPLICANT);
+        String forename = JsonPath.read(serialized, "$.forename");
+
+        assertThat(forename).isEqualTo("some forename");
+    }
+
+    @Test
+    public void serialization_someApplicant_serializeSurname() throws JsonProcessingException {
+        String serialized = objectMapper.writeValueAsString(SOME_APPLICANT);
+        String surname = JsonPath.read(serialized, "$.surname");
+
+        assertThat(surname).isEqualTo("some surname");
+    }
+
+    @Test
+    public void serialization_someApplicant_serializeDateOfBirth() throws JsonProcessingException {
+        String serialized = objectMapper.writeValueAsString(SOME_APPLICANT);
+        String dateOfBirth = JsonPath.read(serialized, "$.dateOfBirth");
+
+        assertThat(dateOfBirth).isEqualTo(SOME_DATE_OF_BIRTH);
+    }
+
+    @Test
+    public void serialization_someApplicant_serializeNino() throws JsonProcessingException {
+        String serialized = objectMapper.writeValueAsString(SOME_APPLICANT);
+        String nino = JsonPath.read(serialized, "$.nino");
+
+        assertThat(nino).isEqualTo("some nino");
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/testrunner/domain/FinancialStatusRequestTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/testrunner/domain/FinancialStatusRequestTest.java
@@ -1,9 +1,62 @@
 package uk.gov.digital.ho.pttg.testrunner.domain;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
 import org.junit.Test;
+import uk.gov.digital.ho.pttg.application.ServiceConfiguration;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class FinancialStatusRequestTest {
 
-//    @Test
-//    public void serialization_
+    private static final String SOME_DATE_OF_BIRTH = "1990-01-01";
+    private static final String SOME_OTHER_DATE_OF_BIRTH = "1991-02-02";
+    private static final List<Applicant> SOME_APPLICANTS = Arrays.asList(new Applicant("some forename", "some surname", LocalDate.parse(SOME_DATE_OF_BIRTH), "some nino"),
+                                                                         new Applicant("some other forename", "some other surname", LocalDate.parse(SOME_OTHER_DATE_OF_BIRTH), "some other nino"));
+    private static final String SOME_APPLICATION_RAISED_DATE = "2019-08-20";
+    private static final Integer SOME_DEPENDANTS = 4;
+    private final FinancialStatusRequest SOME_REQUEST = new FinancialStatusRequest(SOME_APPLICANTS, LocalDate.parse(SOME_APPLICATION_RAISED_DATE), SOME_DEPENDANTS);
+
+    private ObjectMapper objectMapper = new ServiceConfiguration().createObjectMapper();
+
+    @Test
+    public void serialization_someRequest_serializeApplicants() throws JsonProcessingException {
+        String serialized = objectMapper.writeValueAsString(SOME_REQUEST);
+        String applicant1Forename = JsonPath.read(serialized, "$.individuals[0].forename");
+        String applicant2DateOfBirth = JsonPath.read(serialized, "$.individuals[1].dateOfBirth");
+        assertThat(applicant1Forename).isEqualTo("some forename");
+        assertThat(applicant2DateOfBirth).isEqualTo(SOME_OTHER_DATE_OF_BIRTH);
+    }
+
+    @Test
+    public void serialization_someRequest_serializeApplicationRaisedDate() throws JsonProcessingException {
+        String serialized = objectMapper.writeValueAsString(SOME_REQUEST);
+        String applicationRaisedDate = JsonPath.read(serialized, "$.applicationRaisedDate");
+
+        assertThat(applicationRaisedDate).isEqualTo(SOME_APPLICATION_RAISED_DATE);
+    }
+
+    @Test
+    public void serialization_someRequest_serializeDependants() throws JsonProcessingException {
+        String serialized = objectMapper.writeValueAsString(SOME_REQUEST);
+        int dependants = JsonPath.read(serialized, "$.dependants");
+
+        assertThat(dependants).isEqualTo(SOME_DEPENDANTS);
+    }
+
+    @Test
+    public void serialization_requestWithoutDependants_notInRequest() throws JsonProcessingException {
+        FinancialStatusRequest requestWithoutDependants = new FinancialStatusRequest(SOME_APPLICANTS, LocalDate.parse(SOME_APPLICATION_RAISED_DATE), null);
+        String serialized = objectMapper.writeValueAsString(requestWithoutDependants);
+
+        assertThatThrownBy(() -> JsonPath.read(serialized, "$.dependants"))
+                .isInstanceOf(PathNotFoundException.class);
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/testrunner/domain/FinancialStatusRequestTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/testrunner/domain/FinancialStatusRequestTest.java
@@ -1,0 +1,9 @@
+package uk.gov.digital.ho.pttg.testrunner.domain;
+
+import org.junit.Test;
+
+public class FinancialStatusRequestTest {
+
+//    @Test
+//    public void serialization_
+}


### PR DESCRIPTION
Implemented the smoke test for IPS. It is run when this service is hit on the /smoketests endpoint and the success/failure is communicated back to the caller as HTTP status.

There's a lot of leftover stuff from the previous design (as a job) that is not needed anymore but I will raise a separate PR for the tidying up. This PR is already large enough.

Accompanied by https://github.com/UKHomeOffice/kube-pttg-ip-smoke-tests/pull/7

I intend to merge once approved.