### PR TITLE
EE-6825 Fixing the smoke test

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
@@ -38,7 +38,7 @@ public class SmokeTestsService {
 
     private boolean isIdentityUnmatched(HttpStatusCodeException e) {
         try {
-            boolean hasNotMatchedCode = JsonPath.read(e.getResponseBodyAsString(), "$.code").equals("0009");
+            boolean hasNotMatchedCode = JsonPath.read(e.getResponseBodyAsString(), "$.status.code").equals("0009");
             return e.getStatusCode().equals(HttpStatus.NOT_FOUND) && hasNotMatchedCode;
         } catch (PathNotFoundException ignored) {
             return false;

--- a/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceIT.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceIT.java
@@ -47,7 +47,7 @@ public class SmokeTestsResourceIT {
         mockIpsService.expect(requestTo(containsString("/incomeproving/v3/individual/financialstatus")))
                       .andExpect(method(POST))
                       .andExpect(jsonPath("$.individuals[0].forename", equalTo("smoke")))
-                      .andRespond(withStatus(HttpStatus.NOT_FOUND).body("{\"code\": \"0009\", \"message\": \"Resource not found\"}"));
+                      .andRespond(withStatus(HttpStatus.NOT_FOUND).body("{\"status\":{\"code\":\"0009\",\"message\":\"Resource not found: /smoketests\"}}"));
 
         ResponseEntity<Void> response = testRestTemplate.exchange("/smoketests", POST, new HttpEntity<>(""), Void.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/src/test/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsServiceTest.java
@@ -70,7 +70,7 @@ public class SmokeTestsServiceTest {
 
     @Test
     public void runSmokeTests_financialStatusRequestNoMatch_returnSuccess() {
-        String notFoundMessage = "{\"code\": \"0009\", \"message\": \"any message\"}";
+        String notFoundMessage = "{\"status\":{\"code\":\"0009\",\"message\":\"Resource not found: /smoketests\"}}";
         given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(getHttpClientErrorException(NOT_FOUND, notFoundMessage));
 
         SmokeTestsResult testsResult = service.runSmokeTests();


### PR DESCRIPTION
Changing to expect the correct response when an identity is not matched - I forgot the '$.status' part.

I intend to merge once approved.