### PR TITLE
EE-6825 Fixing smoke test

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 @AllArgsConstructor
 public class SmokeTestsService {
 
+    private static final String TEST_NINO = "AA000000A";
     private final IpsClient ipsClient;
     private final Clock clock;
 
@@ -37,16 +38,35 @@ public class SmokeTestsService {
     }
 
     private boolean isIdentityUnmatched(HttpStatusCodeException e) {
+        if (!isHttpNotFound(e.getStatusCode())) {
+            return false;
+        }
+
+        String errorResponse = e.getResponseBodyAsString();
+
         try {
-            boolean hasNotMatchedCode = JsonPath.read(e.getResponseBodyAsString(), "$.status.code").equals("0009");
-            return e.getStatusCode().equals(HttpStatus.NOT_FOUND) && hasNotMatchedCode;
+            boolean hasNotMatchedCode = readJsonPath(errorResponse, "$.status.code").equals("0009");
+            boolean containsNino = readJsonPath(errorResponse, "$.status.message").contains(getUnredactedNinoPart(TEST_NINO));
+            return hasNotMatchedCode && containsNino;
         } catch (PathNotFoundException ignored) {
             return false;
         }
     }
 
+    private String getUnredactedNinoPart(String nino) {
+        return nino.substring(0, 5);
+    }
+
+    private String readJsonPath(String json, String path) {
+        return JsonPath.read(json, path);
+    }
+
+    private boolean isHttpNotFound(HttpStatus httpStatus) {
+        return httpStatus.equals(HttpStatus.NOT_FOUND);
+    }
+
     private FinancialStatusRequest someRequest() {
-        Applicant someApplicant = new Applicant("smoke", "tests", LocalDate.now(clock), "AA000000A");
+        Applicant someApplicant = new Applicant("smoke", "tests", LocalDate.now(clock), TEST_NINO);
         return new FinancialStatusRequest(Collections.singletonList(someApplicant), LocalDate.now(clock), 0);
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsService.java
@@ -19,7 +19,7 @@ import java.util.Collections;
 @AllArgsConstructor
 public class SmokeTestsService {
 
-    private static final String TEST_NINO = "AA000000A";
+    private static final String TEST_NINO = "QQ123456C";
     private final IpsClient ipsClient;
     private final Clock clock;
 

--- a/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceIT.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceIT.java
@@ -47,7 +47,7 @@ public class SmokeTestsResourceIT {
         mockIpsService.expect(requestTo(containsString("/incomeproving/v3/individual/financialstatus")))
                       .andExpect(method(POST))
                       .andExpect(jsonPath("$.individuals[0].forename", equalTo("smoke")))
-                      .andRespond(withStatus(HttpStatus.NOT_FOUND).body("{\"status\":{\"code\":\"0009\",\"message\":\"Resource not found: AA000****\"}}"));
+                      .andRespond(withStatus(HttpStatus.NOT_FOUND).body("{\"status\":{\"code\":\"0009\",\"message\":\"Resource not found: QQ123****\"}}"));
 
         ResponseEntity<Void> response = testRestTemplate.exchange("/smoketests", POST, new HttpEntity<>(""), Void.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceIT.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceIT.java
@@ -47,7 +47,7 @@ public class SmokeTestsResourceIT {
         mockIpsService.expect(requestTo(containsString("/incomeproving/v3/individual/financialstatus")))
                       .andExpect(method(POST))
                       .andExpect(jsonPath("$.individuals[0].forename", equalTo("smoke")))
-                      .andRespond(withStatus(HttpStatus.NOT_FOUND).body("{\"status\":{\"code\":\"0009\",\"message\":\"Resource not found: /smoketests\"}}"));
+                      .andRespond(withStatus(HttpStatus.NOT_FOUND).body("{\"status\":{\"code\":\"0009\",\"message\":\"Resource not found: AA000****\"}}"));
 
         ResponseEntity<Void> response = testRestTemplate.exchange("/smoketests", POST, new HttpEntity<>(""), Void.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/src/test/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsServiceTest.java
@@ -70,12 +70,22 @@ public class SmokeTestsServiceTest {
 
     @Test
     public void runSmokeTests_financialStatusRequestNoMatch_returnSuccess() {
-        String notFoundMessage = "{\"status\":{\"code\":\"0009\",\"message\":\"Resource not found: /smoketests\"}}";
+        String notFoundMessage = "{\"status\":{\"code\":\"0009\",\"message\":\"Resource not found: AA000****\"}}";
         given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(getHttpClientErrorException(NOT_FOUND, notFoundMessage));
 
         SmokeTestsResult testsResult = service.runSmokeTests();
 
         assertThat(testsResult).isEqualTo(SmokeTestsResult.SUCCESS);
+    }
+
+    @Test
+    public void runSmokeTests_noHandlerFound_returnFailure() {
+        String noHandlerFoundMessage = "{\"status\":{\"code\":\"0009\",\"message\":\"Resource not found: /smoketests\"}}";
+        given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(getHttpClientErrorException(NOT_FOUND, noHandlerFoundMessage));
+
+        SmokeTestsResult testsResult = service.runSmokeTests();
+
+        assertThat(testsResult).isEqualTo(new SmokeTestsResult(false, noHandlerFoundMessage));
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsServiceTest.java
@@ -53,7 +53,7 @@ public class SmokeTestsServiceTest {
 
         then(mockIpsClient).should().sendFinancialStatusRequest(requestCaptor.capture());
         FinancialStatusRequest expectedRequest = new FinancialStatusRequest(
-                Collections.singletonList(new Applicant("smoke", "tests", LocalDate.now(fixedClock), "AA000000A")),
+                Collections.singletonList(new Applicant("smoke", "tests", LocalDate.now(fixedClock), "QQ123456C")),
                 LocalDate.now(fixedClock),
                 0);
         assertThat(requestCaptor.getValue()).isEqualTo(expectedRequest);
@@ -70,7 +70,7 @@ public class SmokeTestsServiceTest {
 
     @Test
     public void runSmokeTests_financialStatusRequestNoMatch_returnSuccess() {
-        String notFoundMessage = "{\"status\":{\"code\":\"0009\",\"message\":\"Resource not found: AA000****\"}}";
+        String notFoundMessage = "{\"status\":{\"code\":\"0009\",\"message\":\"Resource not found: QQ123****\"}}";
         given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(getHttpClientErrorException(NOT_FOUND, notFoundMessage));
 
         SmokeTestsResult testsResult = service.runSmokeTests();


### PR DESCRIPTION
 Making it so that it will fail for a proper 'not found' and succeed for an unmatched identity. pttg-ip-api returns status "0009" for both and it's the presence of a redacted Nino in the response that can be used to distinguish them.