### PR TITLE
Ee 6825 use component trace header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     compile group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
-    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
     compile group: 'com.google.guava', name: 'guava', version: '28.1-jre'
 
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,8 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     compile group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
+    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
+    compile group: 'com.google.guava', name: 'guava', version: '28.1-jre'
 
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
 

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/ComponentHeaderChecker.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/ComponentHeaderChecker.java
@@ -22,7 +22,6 @@ public class ComponentHeaderChecker {
                                                              .flatMap(ComponentHeaderChecker::splitComponents)
                                                              .collect(Collectors.toSet());
         return componentsPresent.equals(ALL_EXPECTED_COMPONENTS);
-
     }
 
     private static Stream<? extends String> splitComponents(String header) {

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/ComponentHeaderChecker.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/ComponentHeaderChecker.java
@@ -1,0 +1,29 @@
+package uk.gov.digital.ho.pttg.testrunner;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ComponentHeaderChecker {
+    private static final Set<String> ALL_EXPECTED_COMPONENTS = ImmutableSet.of("pttg-ip-api", "pttg-ip-hmrc", "pttg-ip-audit", "HMRC");
+
+    public boolean checkAllComponentsPresent(List<String> componentTraceHeaders) {
+        if (componentTraceHeaders == null) {
+            return false;
+        }
+
+        Set<String> componentsPresent = componentTraceHeaders.stream()
+                                                             .flatMap(ComponentHeaderChecker::splitComponents)
+                                                             .collect(Collectors.toSet());
+        return componentsPresent.equals(ALL_EXPECTED_COMPONENTS);
+
+    }
+
+    private static Stream<? extends String> splitComponents(String header) {
+        return Arrays.stream(header.split(","));
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/ComponentHeaderChecker.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/ComponentHeaderChecker.java
@@ -1,6 +1,7 @@
 package uk.gov.digital.ho.pttg.testrunner;
 
 import com.google.common.collect.ImmutableSet;
+import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@Component
 public class ComponentHeaderChecker {
     private static final Set<String> ALL_EXPECTED_COMPONENTS = ImmutableSet.of("pttg-ip-api", "pttg-ip-hmrc", "pttg-ip-audit", "HMRC");
 

--- a/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceIT.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceIT.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -44,10 +45,12 @@ public class SmokeTestsResourceIT {
 
     @Test
     public void runSmokeTests_testSuccess_returnSuccess() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("x-component-trace", "pttg-ip-api,pttg-ip-hmrc,pttg-ip-audit,pttg-ip-hmrc-access-code");
         mockIpsService.expect(requestTo(containsString("/incomeproving/v3/individual/financialstatus")))
                       .andExpect(method(POST))
                       .andExpect(jsonPath("$.individuals[0].forename", equalTo("smoke")))
-                      .andRespond(withStatus(HttpStatus.NOT_FOUND).body("{\"status\":{\"code\":\"0009\",\"message\":\"Resource not found: QQ123****\"}}"));
+                      .andRespond(withServerError().headers(headers));
 
         ResponseEntity<Void> response = testRestTemplate.exchange("/smoketests", POST, new HttpEntity<>(""), Void.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -55,14 +58,13 @@ public class SmokeTestsResourceIT {
 
     @Test
     public void runSmokeTests_testFailure_returnFailure() {
-        String someErrorMessage = "some error";
         mockIpsService.expect(requestTo(containsString("/incomeproving/v3/individual/financialstatus")))
                       .andExpect(method(POST))
                       .andExpect(jsonPath("$.individuals[0].forename", equalTo("smoke")))
-                      .andRespond(withServerError().body(someErrorMessage));
+                      .andRespond(withServerError().headers(HttpHeaders.EMPTY));
 
         ResponseEntity<String> response = testRestTemplate.exchange("/smoketests", POST, new HttpEntity<>(""), String.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-        assertThat(response.getBody()).contains(someErrorMessage);
+        assertThat(response.getBody()).contains("x-component-trace header");
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceIT.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/SmokeTestsResourceIT.java
@@ -20,7 +20,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
@@ -46,7 +45,7 @@ public class SmokeTestsResourceIT {
     @Test
     public void runSmokeTests_testSuccess_returnSuccess() {
         HttpHeaders headers = new HttpHeaders();
-        headers.add("x-component-trace", "pttg-ip-api,pttg-ip-hmrc,pttg-ip-audit,pttg-ip-hmrc-access-code");
+        headers.add("x-component-trace", "pttg-ip-api,pttg-ip-hmrc,pttg-ip-audit,HMRC");
         mockIpsService.expect(requestTo(containsString("/incomeproving/v3/individual/financialstatus")))
                       .andExpect(method(POST))
                       .andExpect(jsonPath("$.individuals[0].forename", equalTo("smoke")))
@@ -65,6 +64,6 @@ public class SmokeTestsResourceIT {
 
         ResponseEntity<String> response = testRestTemplate.exchange("/smoketests", POST, new HttpEntity<>(""), String.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-        assertThat(response.getBody()).contains("x-component-trace header");
+        assertThat(response.getBody()).contains("Components missing");
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/testrunner/ComponentHeaderCheckerTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/testrunner/ComponentHeaderCheckerTest.java
@@ -1,0 +1,67 @@
+package uk.gov.digital.ho.pttg.testrunner;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ComponentHeaderCheckerTest {
+
+    private final ComponentHeaderChecker componentHeaderChecker = new ComponentHeaderChecker();
+
+    @Test
+    public void checkAllComponentsPresent_null_returnFalse() {
+        assertThat(componentHeaderChecker.checkAllComponentsPresent(null)).isFalse();
+    }
+
+    @Test
+    public void checkAllComponentsPresent_emptyList_returnFalse() {
+        assertThat(componentHeaderChecker.checkAllComponentsPresent(emptyList())).isFalse();
+    }
+
+    @Test
+    public void checkAllComponentsPresent_singleHeaderAllComponents_returnTrue() {
+        List<String> singleHeaderAllComponents = singletonList("pttg-ip-api,pttg-ip-hmrc,pttg-ip-audit,HMRC");
+        assertThat(componentHeaderChecker.checkAllComponentsPresent(singleHeaderAllComponents)).isTrue();
+    }
+
+    @Test
+    public void checkAllComponentsPresent_allComponentsOneHeaderSomeRepeated_returnTrue() {
+        List<String> allComponentsWithRepeats = singletonList("pttg-ip-api,pttg-ip-audit,pttg-ip-hmrc,pttg-ip-audit,HMRC,HMRC");
+        assertThat(componentHeaderChecker.checkAllComponentsPresent(allComponentsWithRepeats)).isTrue();
+    }
+
+    @Test
+    public void checkAllComponentsPresent_componentMissingSingleHeader_returnFalse() {
+        List<String> singleHeaderWithMissing = singletonList("pttg-ip-hmrc,HMRC,pttg-ip-audit");
+        assertThat(componentHeaderChecker.checkAllComponentsPresent(singleHeaderWithMissing)).isFalse();
+    }
+
+    @Test
+    public void checkAllComponentsPresent_allComponentsSeparateHeaders_returnTrue() {
+        List<String> allComponentsSeparateHeaders = asList("pttg-ip-audit", "pttg-ip-hmrc", "HMRC", "pttg-ip-api");
+        assertThat(componentHeaderChecker.checkAllComponentsPresent(allComponentsSeparateHeaders)).isTrue();
+    }
+
+    @Test
+    public void checkAllComponentsPresent_allComponentsSeparateHeadersSomeRepeated_returnTrue() {
+        List<String> allComponentsWithRepeats = asList("pttg-ip-hmrc", "pttg-ip-hmrc", "pttg-ip-audit", "HMRC", "pttg-ip-hmrc", "HMRC", "pttg-ip-api");
+        assertThat(componentHeaderChecker.checkAllComponentsPresent(allComponentsWithRepeats)).isTrue();
+    }
+
+    @Test
+    public void checkAllComponentsPresent_separateHeadersComponentsMissing_returnFalse() {
+        List<String> multipleHeadersWithMissing = asList("pttg-ip-api", "pttg-ip-audit", "pttg-ip-audit");
+        assertThat(componentHeaderChecker.checkAllComponentsPresent(multipleHeadersWithMissing)).isFalse();
+    }
+
+    @Test
+    public void checkAllComponentsPresent_allPresent_someInSameHeader_returnTrue() {
+        List<String> allComponentsSomeSameHeader = asList("pttg-ip-hmrc,pttg-ip-hmrc", "pttg-ip-audit", "HMRC,pttg-ip-hmrc", "pttg-ip-api");
+        assertThat(componentHeaderChecker.checkAllComponentsPresent(allComponentsSomeSameHeader)).isTrue();
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsServiceTest.java
@@ -114,18 +114,4 @@ public class SmokeTestsServiceTest {
 
         assertThat(service.runSmokeTests()).isEqualTo(SmokeTestsResult.SUCCESS);
     }
-
-    @Test
-    public void runSmokeTests_multipleComponentTraceHeadersAllComponents_returnSuccess() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("x-component-trace", "pttg-ip-api");
-        headers.add("x-component-trace", "pttg-ip-audit");
-        headers.add("x-component-trace", "pttg-ip-hmrc");
-        headers.add("x-component-trace", "pttg-ip-hmrc-access-code");
-        headers.add("x-component-trace", "HMRC");
-        HttpServerErrorException errorWithoutComponentTrace = new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "any text", headers, null, null);
-        given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(errorWithoutComponentTrace);
-
-        assertThat(service.runSmokeTests()).isEqualTo(SmokeTestsResult.SUCCESS);
-    }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/testrunner/SmokeTestsServiceTest.java
@@ -18,10 +18,11 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.Collections;
 
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
@@ -30,6 +31,8 @@ public class SmokeTestsServiceTest {
 
     @Mock
     private IpsClient mockIpsClient;
+    @Mock
+    private ComponentHeaderChecker mockComponentHeaderChecker;
 
     private SmokeTestsService service;
     private ArgumentCaptor<FinancialStatusRequest> requestCaptor;
@@ -41,7 +44,7 @@ public class SmokeTestsServiceTest {
         Instant instant = Instant.from(anyDate.atStartOfDay().atZone(ZoneId.systemDefault()));
         fixedClock = Clock.fixed(instant, ZoneId.systemDefault());
 
-        service = new SmokeTestsService(mockIpsClient, fixedClock);
+        service = new SmokeTestsService(mockIpsClient, fixedClock, mockComponentHeaderChecker);
 
         requestCaptor = ArgumentCaptor.forClass(FinancialStatusRequest.class);
     }
@@ -52,7 +55,7 @@ public class SmokeTestsServiceTest {
 
         then(mockIpsClient).should().sendFinancialStatusRequest(requestCaptor.capture());
         FinancialStatusRequest expectedRequest = new FinancialStatusRequest(
-                Collections.singletonList(new Applicant("smoke", "tests", LocalDate.now(fixedClock), "QQ123456C")),
+                singletonList(new Applicant("smoke", "tests", LocalDate.now(fixedClock), "QQ123456C")),
                 LocalDate.now(fixedClock),
                 0);
         assertThat(requestCaptor.getValue()).isEqualTo(expectedRequest);
@@ -66,51 +69,58 @@ public class SmokeTestsServiceTest {
     }
 
     @Test
-    public void runSmokeTests_errorWithoutComponentTrace_returnFailure() {
-        HttpServerErrorException errorWithoutComponentTrace = new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "any text", new HttpHeaders(), null, null);
-        given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(errorWithoutComponentTrace);
+    public void runSmokeTests_errorNoHeaders_returnFailure() {
+        HttpServerErrorException exceptionWithoutHeaders = new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "any status text", null, null, null);
+        given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(exceptionWithoutHeaders);
 
-        SmokeTestsResult testsResult = service.runSmokeTests();
-        assertThat(testsResult.success()).isFalse();
+        assertThat(service.runSmokeTests()).isEqualTo(new SmokeTestsResult(false, "No headers"));
     }
 
     @Test
-    public void runSmokeTests_errorWithoutComponentTrace_giveReason() {
-        HttpServerErrorException errorWithoutComponentTrace = new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "any text", new HttpHeaders(), null, null);
-        given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(errorWithoutComponentTrace);
+    public void runSmokeTests_noTraceHeader_passNullToChecker() {
+        HttpServerErrorException exceptionWithoutTraceHeader = new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "any status text", new HttpHeaders(), null, null);
+        given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(exceptionWithoutTraceHeader);
 
-        SmokeTestsResult testsResult = service.runSmokeTests();
-        assertThat(testsResult.reason()).contains("x-component-trace");
+        service.runSmokeTests();
+        then(mockComponentHeaderChecker).should().checkAllComponentsPresent(null);
     }
 
     @Test
-    public void runSmokeTests_errorWithInvalidComponentTrace_returnFailure() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("x-component-trace", "pttg-ip-api");
-        HttpServerErrorException errorWithoutComponentTrace = new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "any text", headers, null, null);
-        given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(errorWithoutComponentTrace);
+    public void runSmokeTests_traceHeader_passHeaderToChecker() {
+        HttpHeaders componentTraceHeader = new HttpHeaders();
+        String someComponentTrace = "pttg-ip-api,pttg-ip-audit,pttg-ip-hmrc,pttg-ip-audit,HMRC";
+        componentTraceHeader.add("x-component-trace", someComponentTrace);
 
-        SmokeTestsResult testsResult = service.runSmokeTests();
-        assertThat(testsResult.success()).isFalse();
+        HttpServerErrorException exceptionWithTraceHeader = new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "any status text", componentTraceHeader, null, null);
+        given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(exceptionWithTraceHeader);
+
+        service.runSmokeTests();
+
+        then(mockComponentHeaderChecker).should().checkAllComponentsPresent(singletonList(someComponentTrace));
     }
 
     @Test
-    public void runSmokeTests_errorWithInvalidComponentTrace_giveReason() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("x-component-trace", "pttg-ip-api");
-        HttpServerErrorException errorWithoutComponentTrace = new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "any text", headers, null, null);
-        given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(errorWithoutComponentTrace);
+    public void runSmokeTests_failureFromChecker_returnFailure() {
+        HttpHeaders anyComponentHeaders = new HttpHeaders();
+        String anyComponentTrace = "pttg-ip-api,pttg-ip-audit,pttg-ip-hmrc,pttg-ip-audit,HMRC";
+        anyComponentHeaders.add("x-component-trace", anyComponentTrace);
 
-        SmokeTestsResult testsResult = service.runSmokeTests();
-        assertThat(testsResult.reason()).contains("x-component-trace");
+        HttpServerErrorException anyExceptionWithTraceHeader = new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "any status text", anyComponentHeaders, null, null);
+        given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(anyExceptionWithTraceHeader);
+        given(mockComponentHeaderChecker.checkAllComponentsPresent(anyList())).willReturn(false);
+
+        assertThat(service.runSmokeTests()).isEqualTo(new SmokeTestsResult(false, "Components missing from trace"));
     }
 
     @Test
-    public void runSmokeTests_errorWithExpectedComponentTrace_returnSuccess() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("x-component-trace", "pttg-ip-api,pttg-ip-audit,pttg-ip-hmrc,pttg-ip-hmrc-access-code,HMRC");
-        HttpServerErrorException errorWithoutComponentTrace = new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "any text", headers, null, null);
-        given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(errorWithoutComponentTrace);
+    public void runSmokeTests_successFromChecker_returnSuccess() {
+        HttpHeaders anyComponentHeaders = new HttpHeaders();
+        String anyComponentTrace = "pttg-ip-api,pttg-ip-audit,pttg-ip-hmrc,pttg-ip-audit,HMRC";
+        anyComponentHeaders.add("x-component-trace", anyComponentTrace);
+
+        HttpServerErrorException anyExceptionWithTraceHeader = new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "any status text", anyComponentHeaders, null, null);
+        given(mockIpsClient.sendFinancialStatusRequest(any())).willThrow(anyExceptionWithTraceHeader);
+        given(mockComponentHeaderChecker.checkAllComponentsPresent(anyList())).willReturn(true);
 
         assertThat(service.runSmokeTests()).isEqualTo(SmokeTestsResult.SUCCESS);
     }


### PR DESCRIPTION
Change smoke tests to work by inspecting the x-component-trace header, rather than relying on the HTTP response code.

As smoke tests aren't being used yet I will merge once approved.