### PR TITLE
EE-6825 Whitespace in trace

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/testrunner/ComponentHeaderChecker.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/testrunner/ComponentHeaderChecker.java
@@ -20,6 +20,7 @@ public class ComponentHeaderChecker {
 
         Set<String> componentsPresent = componentTraceHeaders.stream()
                                                              .flatMap(ComponentHeaderChecker::splitComponents)
+                                                             .map(String::trim)
                                                              .collect(Collectors.toSet());
         return componentsPresent.equals(ALL_EXPECTED_COMPONENTS);
     }

--- a/src/test/java/uk/gov/digital/ho/pttg/testrunner/ComponentHeaderCheckerTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/testrunner/ComponentHeaderCheckerTest.java
@@ -36,6 +36,12 @@ public class ComponentHeaderCheckerTest {
     }
 
     @Test
+    public void checkAllComponentsPresent_allComponentsOneHeader_withSpaces_returnTrue() {
+        List<String> allComponentsWithSpaces = singletonList("pttg-ip-audit, pttg-ip-api ,pttg-ip-hmrc  ,  HMRC");
+        assertThat(componentHeaderChecker.checkAllComponentsPresent(allComponentsWithSpaces)).isTrue();
+    }
+
+    @Test
     public void checkAllComponentsPresent_componentMissingSingleHeader_returnFalse() {
         List<String> singleHeaderWithMissing = singletonList("pttg-ip-hmrc,HMRC,pttg-ip-audit");
         assertThat(componentHeaderChecker.checkAllComponentsPresent(singleHeaderWithMissing)).isFalse();
@@ -63,5 +69,12 @@ public class ComponentHeaderCheckerTest {
     public void checkAllComponentsPresent_allPresent_someInSameHeader_returnTrue() {
         List<String> allComponentsSomeSameHeader = asList("pttg-ip-hmrc,pttg-ip-hmrc", "pttg-ip-audit", "HMRC,pttg-ip-hmrc", "pttg-ip-api");
         assertThat(componentHeaderChecker.checkAllComponentsPresent(allComponentsSomeSameHeader)).isTrue();
+    }
+
+    @Test
+    public void checkAllComponentsPresent_allPresentMultipleHeaders_someSpaces_returnTrue() {
+        List<String> allComponentsWithSpaces = asList("pttg-ip-audit ", " pttg-ip-hmrc", " HMRC ", "   pttg-ip-api");
+        assertThat(componentHeaderChecker.checkAllComponentsPresent(allComponentsWithSpaces)).isTrue();
+
     }
 }


### PR DESCRIPTION
Making the ComponentHeaderChecker tolerant of leading and traiiling whitespace. I will merge once approved.